### PR TITLE
chore: fake Grist data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ For rendering the map, a combination of [MapLibre GL JS](https://maplibre.org/ma
 ### Steps
 
 1. Install dependencies via `npm install`
-2. Create a file `.env.development.local` and fill it according to `.env.example`. This will fetch data from a table with fake data for development.
+2. Create a file `.env.development.local` and fill it according to `.env.example`. The environment variables will connect to our development Grist instance which currently contains fake data instead of real facilities data. This is because in development mode we want to have the expected amount of records (~300) while the real dataset is currently being collected.
 3. Run `npm run dev` to get a development server running at [http://localhost:3000](http://localhost:3000)
 4. Explore the data on the map or make changes to the code
 
 > If you want to start the app with the production table data, please change the values of 
 `.env.development.local` to point to the production table.
+
 ## Notes
 
 ### Accessing the Grist API from a Next API route

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ For rendering the map, a combination of [MapLibre GL JS](https://maplibre.org/ma
 ### Steps
 
 1. Install dependencies via `npm install`
-2. Create a file `/.env.development.local` and fill it according to `/.env.example`
+2. Create a file `.env.development.local` and fill it according to `.env.example`. This will fetch data from a table with fake data for development.
 3. Run `npm run dev` to get a development server running at [http://localhost:3000](http://localhost:3000)
 4. Explore the data on the map or make changes to the code
 
+> If you want to start the app with the production table data, please change the values of 
+`.env.development.local` to point to the production table.
 ## Notes
 
 ### Accessing the Grist API from a Next API route

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
         "swr": "1.2.2"
       },
       "devDependencies": {
+        "@faker-js/faker": "7.5.0",
         "@testing-library/jest-dom": "5.16.4",
         "@testing-library/react": "12.1.4",
         "@testing-library/user-event": "14.2.0",
         "@types/node": "17.0.21",
+        "@types/node-fetch": "2.6.2",
         "@types/react": "17.0.47",
         "@typescript-eslint/eslint-plugin": "5.30.6",
         "@typescript-eslint/parser": "5.30.6",
@@ -34,6 +36,7 @@
         "jest": "28.1.0",
         "jest-environment-jsdom": "28.1.0",
         "jest-fetch-mock": "3.0.3",
+        "node-fetch": "2.6.7",
         "postcss": "8.4.14",
         "prettier": "2.7.1",
         "tailwindcss": "3.1.6",
@@ -677,6 +680,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.5.0.tgz",
+      "integrity": "sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2080,6 +2093,30 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
@@ -9469,6 +9506,12 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@faker-js/faker": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.5.0.tgz",
+      "integrity": "sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -10554,6 +10597,29 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
+    },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/parse5": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "swr": "1.2.2"
   },
   "devDependencies": {
+    "@faker-js/faker": "7.5.0",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "12.1.4",
     "@testing-library/user-event": "14.2.0",
     "@types/node": "17.0.21",
+    "@types/node-fetch": "2.6.2",
     "@types/react": "17.0.47",
     "@typescript-eslint/eslint-plugin": "5.30.6",
     "@typescript-eslint/parser": "5.30.6",
@@ -40,6 +42,7 @@
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
     "jest-fetch-mock": "3.0.3",
+    "node-fetch": "2.6.7",
     "postcss": "8.4.14",
     "prettier": "2.7.1",
     "tailwindcss": "3.1.6",

--- a/scripts/createFakeGristData.ts
+++ b/scripts/createFakeGristData.ts
@@ -1,0 +1,128 @@
+import fetch from 'node-fetch'
+import { TableRowType } from '@common/types/gristData'
+import { loadEnvConfig } from '@next/env'
+import { faker } from '@faker-js/faker/locale/de'
+
+const projectDir = process.cwd()
+loadEnvConfig(projectDir, true)
+
+// Taken from: https://stackoverflow.com/a/19270021
+const getRandomArray = (arr: string[], n: number): string[] => {
+  const result = new Array(n)
+  let len = arr.length
+  const taken = new Array(len)
+  if (n > len)
+    throw new RangeError('getRandom: more elements taken than available')
+  while (n--) {
+    const x = Math.floor(Math.random() * len)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    result[n] = arr[x in taken ? taken[x] : x]
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    taken[x] = --len in taken ? taken[len] : len
+  }
+  return result as string[]
+}
+
+const POST_RECORDS_URL = `${
+  process.env.NEXT_SECRET_GRIST_DOMAIN || ''
+}/api/docs/${process.env.NEXT_SECRET_GRIST_DOC_ID || ''}/tables/${
+  process.env.NEXT_SECRET_GRIST_TABLE || ''
+}/records`
+
+const fakeData: Omit<TableRowType, 'id'>[] = Array.from(Array(300)).map(() => {
+  return {
+    fields: {
+      Anmeldung_gewunscht: 'ja',
+      Ansprechperson_1_Anrede: 'Frau',
+      Ansprechperson_1_Nachname: faker.name.lastName(),
+      Ansprechperson_1_Titel: 'Dr.',
+      Ansprechperson_1_Vorname: faker.name.firstName('female'),
+      Ansprechperson_2_Anrede: 'Herr',
+      Ansprechperson_2_Nachname: faker.name.lastName(),
+      Ansprechperson_2_Titel: '',
+      Ansprechperson_2_Vorname: faker.name.firstName('male'),
+      Ausschlie_lich_nach_Meldeadresse: 'ja',
+      Barrierefreiheit: 'nein',
+      Beratungsmoglichkeiten: getRandomArray(
+        [
+          'Vor Ort',
+          'Telefonberatung',
+          'Rückrufservice',
+          'Außerhalb der Einrichtung',
+        ],
+        3
+      ).join(';'),
+      Bezirk: 'Lichtenberg',
+      c24_h_7_Tage: 'nein',
+      Montag: '09:00 - 17:00',
+      Dienstag: '12:00 - 22:00',
+      Mittwoch: '09:00 - 12:00',
+      Donnerstag: '18:00 - 24:00',
+      Freitag: '10:00 - 13:00',
+      Samstag: 'geschlossen',
+      Sonntag: 'geschlossen',
+      Einrichtung: faker.company.name(),
+      EMail: faker.internet.email(),
+      Hausnummer: `${faker.datatype.number({ max: 350 })}`,
+      Kategorie: 'Kontakt-und Beratungsstellen',
+      // TODO: Fakers latitude produces weird, nor really random-looking results. Improve that.
+      lat: parseFloat(
+        faker.address.latitude(52.645919276537, 52.54470760200334, 6)
+      ),
+      // TODO: Fakers latitude produces weird, nor really random-looking results. Improve that.
+      long2: parseFloat(
+        faker.address.longitude(13.381266029328117, 13.349337606247445, 6)
+      ),
+      PLZ: `${faker.datatype.number({ min: 10_000, max: 13_000 })}`,
+      Reichweite: 'Bezirk',
+      Schlagworte: getRandomArray(
+        [
+          'Arbeit und Beschäftigung',
+          'Erwachsene',
+          'Alkohol und Medikamente',
+          'Sucht',
+          'Geflüchtete',
+          'LSTBIQ',
+        ],
+        3
+      ).join(';'),
+      Sprachen: getRandomArray(
+        ['Deutsch', 'Englisch', 'Türkisch', 'Polnisch', 'Arabisch', 'Spanisch'],
+        3
+      ).join(';'),
+      Stadtteil: 'Lichtenberg',
+      Stadtteile_Regionen: '',
+      Strasse: faker.address.street(),
+      Telefonnummer: faker.phone.number('+49 30 ### ### ##'),
+      Trager: faker.company.name(),
+      Uber_uns: faker.lorem.paragraph(),
+      Website: faker.internet.url(),
+      Weitere_Offnungszeiten: '',
+      Wichtige_Hinweise: '',
+      Zusatz: '',
+    } as TableRowType['fields'],
+  }
+})
+
+const postRows = async (): Promise<void> => {
+  const response = await fetch(POST_RECORDS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.NEXT_SECRET_GRIST_API_KEY || ''}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      records: fakeData,
+    }),
+  })
+  //eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const responseData = await response.json()
+  console.log('Successfully inserted fake data:')
+  console.log(responseData)
+}
+
+try {
+  void postRows()
+} catch (error) {
+  console.error(error)
+}

--- a/scripts/createFakeGristData.ts
+++ b/scripts/createFakeGristData.ts
@@ -14,6 +14,9 @@ const createRandomArrayFromArray = (
   return shuffledArray.slice(0, newArrayLength)
 }
 
+const getRandomNumberInRange = (min: number, max: number): number =>
+  Math.floor(Math.random() * (max - min) + min)
+
 const POST_RECORDS_URL = `${
   process.env.NEXT_SECRET_GRIST_DOMAIN || ''
 }/api/docs/${process.env.NEXT_SECRET_GRIST_DOC_ID || ''}/tables/${
@@ -41,7 +44,7 @@ const fakeData: Omit<TableRowType, 'id'>[] = Array.from(Array(300)).map(() => {
           'Rückrufservice',
           'Außerhalb der Einrichtung',
         ],
-        3
+        getRandomNumberInRange(1, 4)
       ).join(';'),
       Bezirk: 'Lichtenberg',
       c24_h_7_Tage: 'nein',
@@ -75,11 +78,11 @@ const fakeData: Omit<TableRowType, 'id'>[] = Array.from(Array(300)).map(() => {
           'Geflüchtete',
           'LSTBIQ',
         ],
-        3
+        getRandomNumberInRange(1, 6)
       ).join(';'),
       Sprachen: createRandomArrayFromArray(
         ['Deutsch', 'Englisch', 'Türkisch', 'Polnisch', 'Arabisch', 'Spanisch'],
-        3
+        getRandomNumberInRange(1, 6)
       ).join(';'),
       Stadtteil: 'Lichtenberg',
       Stadtteile_Regionen: '',

--- a/scripts/createFakeGristData.ts
+++ b/scripts/createFakeGristData.ts
@@ -6,21 +6,12 @@ import { faker } from '@faker-js/faker/locale/de'
 const projectDir = process.cwd()
 loadEnvConfig(projectDir, true)
 
-// Taken from: https://stackoverflow.com/a/19270021
-const getRandomArray = (arr: string[], n: number): string[] => {
-  const result = new Array(n)
-  let len = arr.length
-  const taken = new Array(len)
-  if (n > len)
-    throw new RangeError('getRandom: more elements taken than available')
-  while (n--) {
-    const x = Math.floor(Math.random() * len)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    result[n] = arr[x in taken ? taken[x] : x]
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    taken[x] = --len in taken ? taken[len] : len
-  }
-  return result as string[]
+const createRandomArrayFromArray = (
+  sourceArray: string[],
+  newArrayLength: number
+): string[] => {
+  const shuffledArray = [...sourceArray].sort(() => 0.5 - Math.random())
+  return shuffledArray.slice(0, newArrayLength)
 }
 
 const POST_RECORDS_URL = `${
@@ -43,7 +34,7 @@ const fakeData: Omit<TableRowType, 'id'>[] = Array.from(Array(300)).map(() => {
       Ansprechperson_2_Vorname: faker.name.firstName('male'),
       Ausschlie_lich_nach_Meldeadresse: 'ja',
       Barrierefreiheit: 'nein',
-      Beratungsmoglichkeiten: getRandomArray(
+      Beratungsmoglichkeiten: createRandomArrayFromArray(
         [
           'Vor Ort',
           'Telefonberatung',
@@ -75,7 +66,7 @@ const fakeData: Omit<TableRowType, 'id'>[] = Array.from(Array(300)).map(() => {
       ),
       PLZ: `${faker.datatype.number({ min: 10_000, max: 13_000 })}`,
       Reichweite: 'Bezirk',
-      Schlagworte: getRandomArray(
+      Schlagworte: createRandomArrayFromArray(
         [
           'Arbeit und Beschäftigung',
           'Erwachsene',
@@ -86,7 +77,7 @@ const fakeData: Omit<TableRowType, 'id'>[] = Array.from(Array(300)).map(() => {
         ],
         3
       ).join(';'),
-      Sprachen: getRandomArray(
+      Sprachen: createRandomArrayFromArray(
         ['Deutsch', 'Englisch', 'Türkisch', 'Polnisch', 'Arabisch', 'Spanisch'],
         3
       ).join(';'),

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+  }
+}

--- a/src/common/types/gristData.ts
+++ b/src/common/types/gristData.ts
@@ -45,5 +45,10 @@ export interface TableRowType {
     Weitere_Offnungszeiten: string
     lat: number
     long2: number
+    // The following columns are available in the development table, not currently in the production table (all strings that are semicolon-separated):
+    Themen_Gruppe_1?: string // topics for psychological problems
+    Themen_Gruppe_2?: string // topics for addiction-related problems
+    Themen_Gruppe_3?: string // topics for health and identity-related problems
+    Zielgruppen?: string
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,7 @@
     "./src/**/*.tsx",
     "./pages/**/*.ts",
     "./pages/**/*.tsx",
+    "./scripts/createFakeGristData.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This PR adds a script that was used for adding 300 fake records to a Grist table. The fake data is added to a separate table so that we can simulate the expected amount of records for development without touching the table used for gathering the actual data. For using this table in development, please change your local environment variables.

The script was executed via

```bash
NODE_ENV=development npx ts-node scripts/createFakeGristData.ts
```

Note that the seed script is a rather quick&dirty work and could be improved. Feel free to take a look, discard or change it. Also note that I've tried using Grist's choice list datatype. However, I couldn't find a way to fill this programmatically via their API. That's why the fake data table is currently a mirror of the production table.

---

- [x] create script
- [x] execute script
- [x] add information about fake table to team (env vars)
- [x] add information to README