### PR TITLE
feat: Use cache data for initial build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local
@@ -36,3 +37,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache data
+data

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For rendering the map, a combination of [MapLibre GL JS](https://maplibre.org/ma
 ### Steps
 
 1. Install dependencies via `npm install`
-2. Create a file `/.env.development.local` and fill it according to `/.env.example`
+2. Create a `/.env.development.local` and `/.env` file and fill them according to `/.env.example`
 3. Run `npm run dev` to get a development server running at [http://localhost:3000](http://localhost:3000)
 4. Explore the data on the map or make changes to the code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,13 @@
         "@testing-library/react": "12.1.4",
         "@testing-library/user-event": "14.2.0",
         "@types/node": "17.0.21",
+        "@types/node-fetch": "^2.6.2",
         "@types/react": "17.0.47",
         "@typescript-eslint/eslint-plugin": "5.30.6",
         "@typescript-eslint/parser": "5.30.6",
         "autoprefixer": "10.4.7",
         "babel-plugin-inline-react-svg": "2.0.1",
+        "dotenv": "16.0.3",
         "eslint": "8.20.0",
         "eslint-config-next": "12.2.2",
         "eslint-config-prettier": "8.5.0",
@@ -36,9 +38,11 @@
         "jest": "28.1.0",
         "jest-environment-jsdom": "28.1.0",
         "jest-fetch-mock": "3.0.3",
+        "node-fetch": "2.6.7",
         "postcss": "8.4.14",
         "prettier": "2.7.1",
         "tailwindcss": "3.1.6",
+        "ts-node": "10.8.0",
         "tsconfig-paths-webpack-plugin": "3.5.2",
         "typescript": "4.7.4"
       }
@@ -657,6 +661,28 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.1",
@@ -1929,6 +1955,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -2091,6 +2141,30 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
@@ -3111,6 +3185,12 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -3412,6 +3492,15 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.0.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
@@ -3522,6 +3611,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/earcut": {
@@ -6986,6 +7084,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -8716,6 +8820,64 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
+      "integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -8928,6 +9090,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
@@ -9197,6 +9365,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -9680,6 +9857,27 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.1",
@@ -10637,6 +10835,30 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -10789,6 +11011,29 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
+    },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/parse5": {
       "version": "6.0.3",
@@ -11510,6 +11755,12 @@
       "integrity": "sha512-IeHpLwk3uoci37yoI2Laty59+YqH9x5uR65/yiA0ARAJrTrN4YU0rmauLWfvqOuk77SlNJXj2rM6oT/dBD87+A==",
       "dev": true
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -11743,6 +11994,12 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "diff-sequences": {
       "version": "29.0.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
@@ -11824,6 +12081,12 @@
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true
     },
     "earcut": {
       "version": "2.2.4",
@@ -14460,6 +14723,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -15707,6 +15976,41 @@
         "punycode": "^2.1.1"
       }
     },
+    "ts-node": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
+      "integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        },
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -15860,6 +16164,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "v8-to-istanbul": {
@@ -16058,6 +16368,12 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npm run downloadCacheData && next build",
+    "build": "npm run downloadCacheData && IS_BUILDING=true next build",
     "start": "next start",
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint-fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "npm run downloadCacheData && next build",
     "start": "next start",
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint-fix": "npm run lint -- --fix",
     "test": "jest --maxWorkers=50% --coverage --collectCoverageFrom='./(src|pages)/**/*.ts(x)?' --collectCoverageFrom='!./(src|pages)/**/*.stories.ts(x)?' --collectCoverageFrom='!./src/mocks/**/*'",
     "test:watch": "npm run test -- --watch",
     "test:ci": "jest --runInBand",
-    "type-check": "tsc --project tsconfig.json --pretty --noEmit"
+    "type-check": "tsc --project tsconfig.json --pretty --noEmit",
+    "downloadCacheData": "npx ts-node src/scripts/downloadCacheData.ts"
   },
   "dependencies": {
     "date-fns": "2.29.3",
@@ -26,11 +27,13 @@
     "@testing-library/react": "12.1.4",
     "@testing-library/user-event": "14.2.0",
     "@types/node": "17.0.21",
+    "@types/node-fetch": "^2.6.2",
     "@types/react": "17.0.47",
     "@typescript-eslint/eslint-plugin": "5.30.6",
     "@typescript-eslint/parser": "5.30.6",
     "autoprefixer": "10.4.7",
     "babel-plugin-inline-react-svg": "2.0.1",
+    "dotenv": "16.0.3",
     "eslint": "8.20.0",
     "eslint-config-next": "12.2.2",
     "eslint-config-prettier": "8.5.0",
@@ -42,9 +45,11 @@
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
     "jest-fetch-mock": "3.0.3",
+    "node-fetch": "2.6.7",
     "postcss": "8.4.14",
     "prettier": "2.7.1",
     "tailwindcss": "3.1.6",
+    "ts-node": "10.8.0",
     "tsconfig-paths-webpack-plugin": "3.5.2",
     "typescript": "4.7.4"
   }

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -1,29 +1,33 @@
 import type { GetStaticPaths, GetStaticProps } from 'next'
 import Head from 'next/head'
 import { GristLabelType, TableRowType } from '@common/types/gristData'
-import { getGristTexts } from '@lib/requests/getGristTexts'
 import { useTexts } from '@lib/TextsContext'
 import { Page } from '@common/types/nextPage'
 import { MapLayout } from '@components/MapLayout'
 import { FacilityInfo } from '@components/FacilityInfo'
-import { getGristRecords } from '@lib/requests/getGristRecords'
 import { useRouter } from 'next/router'
 import { mapRecordToMinimum, MinimalRecordType } from '@lib/mapRecordToMinimum'
-import { getGristLabels } from '@lib/requests/getGristLabels'
 import { useEffect } from 'react'
+import { loadCacheData } from '@lib/loadCacheData'
+import { downloadCacheData } from '@lib/cacheDownloader'
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const id = params?.id
   if (!id || Array.isArray(id)) return { notFound: true }
-  const [texts, records, labels] = await Promise.all([
-    getGristTexts(),
-    getGristRecords(),
-    getGristLabels(),
-  ])
-  const minimalRecords = records.map(mapRecordToMinimum)
-  const record = records.find((record) => `${record.id}` === `${id}`)
+  let { texts, records, labels } = await loadCacheData()
+  let record = records.find((r) => `${r.id}` === `${id}`)
 
-  if (!record) return { notFound: true }
+  if (!record) {
+    await downloadCacheData()
+    const newCacheData = await loadCacheData()
+    texts = newCacheData.texts
+    records = newCacheData.records
+    labels = newCacheData.labels
+    record = records.find((r) => `${r.id}` === `${id}`)
+    if (!record) return { notFound: true }
+  }
+
+  const minimalRecords = records.map(mapRecordToMinimum)
 
   return {
     props: { texts, records: minimalRecords, record, labels },
@@ -32,7 +36,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const records = await getGristRecords()
+  const { records } = await loadCacheData()
   return {
     paths: records
       .filter((r) => r?.id && r?.fields)

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -9,23 +9,15 @@ import { useRouter } from 'next/router'
 import { mapRecordToMinimum, MinimalRecordType } from '@lib/mapRecordToMinimum'
 import { useEffect } from 'react'
 import { loadCacheData } from '@lib/loadCacheData'
-import { downloadCacheData } from '@lib/cacheDownloader'
+import { loadData } from '@lib/loadData'
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const id = params?.id
   if (!id || Array.isArray(id)) return { notFound: true }
-  let { texts, records, labels } = await loadCacheData()
-  let record = records.find((r) => `${r.id}` === `${id}`)
+  const { texts, labels, records } = await loadData()
+  const record = records.find((r) => `${r.id}` === `${id}`)
 
-  if (!record) {
-    await downloadCacheData()
-    const newCacheData = await loadCacheData()
-    texts = newCacheData.texts
-    records = newCacheData.records
-    labels = newCacheData.labels
-    record = records.find((r) => `${r.id}` === `${id}`)
-    if (!record) return { notFound: true }
-  }
+  if (!record) return { notFound: true }
 
   const minimalRecords = records.map(mapRecordToMinimum)
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,10 +9,10 @@ import { useIsMobile } from '@lib/hooks/useIsMobile'
 import { LegalFooter } from '@components/LegalFooter'
 import { Page } from '@common/types/nextPage'
 import { LabelsProvider } from '@lib/LabelsContext'
-import { loadCacheData } from '@lib/loadCacheData'
+import { loadData } from '@lib/loadData'
 
 export const getStaticProps: GetStaticProps = async () => {
-  const { texts, records, labels } = await loadCacheData()
+  const { texts, labels, records } = await loadData()
   const recordsWithOnlyLabels = records.map(
     (records) => records.fields.Schlagworte
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,24 +1,18 @@
 import type { GetStaticProps } from 'next'
 import Head from 'next/head'
-import { getGristTexts } from '@lib/requests/getGristTexts'
 import classNames from '@lib/classNames'
 import { WelcomeScreen } from '@components/WelcomeScreen'
 import { WelcomeFilters } from '@components/WelcomeFilters'
 import { useState } from 'react'
-import { getGristRecords } from '@lib/requests/getGristRecords'
 import { GristLabelType, TableRowType } from '@common/types/gristData'
-import { getGristLabels } from '@lib/requests/getGristLabels'
 import { useIsMobile } from '@lib/hooks/useIsMobile'
 import { LegalFooter } from '@components/LegalFooter'
 import { Page } from '@common/types/nextPage'
 import { LabelsProvider } from '@lib/LabelsContext'
+import { loadCacheData } from '@lib/loadCacheData'
 
 export const getStaticProps: GetStaticProps = async () => {
-  const [texts, records, labels] = await Promise.all([
-    getGristTexts(),
-    getGristRecords(),
-    getGristLabels(),
-  ])
+  const { texts, records, labels } = await loadCacheData()
   const recordsWithOnlyLabels = records.map(
     (records) => records.fields.Schlagworte
   )

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -1,24 +1,18 @@
 import type { GetStaticProps } from 'next'
 import Head from 'next/head'
-import { getGristTexts } from '@lib/requests/getGristTexts'
-import { getGristRecords } from '@lib/requests/getGristRecords'
 import { useTexts } from '@lib/TextsContext'
 import { Page } from '@common/types/nextPage'
 import { MapLayout } from '@components/MapLayout'
 import classNames from '@lib/classNames'
 import { FacilityListItem } from '@components/FacilityListItem'
 import { mapRecordToMinimum, MinimalRecordType } from '@lib/mapRecordToMinimum'
-import { getGristLabels } from '@lib/requests/getGristLabels'
 import { GristLabelType } from '@common/types/gristData'
 import { useUrlState } from '@lib/UrlStateContext'
 import { useRouter } from 'next/router'
+import { loadCacheData } from '@lib/loadCacheData'
 
 export const getStaticProps: GetStaticProps = async () => {
-  const [texts, records, labels] = await Promise.all([
-    getGristTexts(),
-    getGristRecords(),
-    getGristLabels(),
-  ])
+  const { texts, records, labels } = await loadCacheData()
   const recordsWithOnlyMinimum = records.map(mapRecordToMinimum)
   return {
     props: {

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -9,10 +9,10 @@ import { mapRecordToMinimum, MinimalRecordType } from '@lib/mapRecordToMinimum'
 import { GristLabelType } from '@common/types/gristData'
 import { useUrlState } from '@lib/UrlStateContext'
 import { useRouter } from 'next/router'
-import { loadCacheData } from '@lib/loadCacheData'
+import { loadData } from '@lib/loadData'
 
 export const getStaticProps: GetStaticProps = async () => {
-  const { texts, records, labels } = await loadCacheData()
+  const { texts, labels, records } = await loadData()
   const recordsWithOnlyMinimum = records.map(mapRecordToMinimum)
   return {
     props: {

--- a/src/common/types/gristData.ts
+++ b/src/common/types/gristData.ts
@@ -1,4 +1,4 @@
-export interface GristLabelType {
+export interface GristLabelType extends Record<string, unknown> {
   id: number
   fields: {
     key: string
@@ -11,7 +11,7 @@ export interface GristLabelType {
 /**
  * This type corresponds to the table row of psychological and other help facilities in Berlin. Note that the keys are subject to change whenever the columns are updated in the spreadsheet.
  */
-export interface TableRowType {
+export interface TableRowType extends Record<string, unknown> {
   id: number
   fields: {
     Einrichtung: string

--- a/src/lib/cacheDownloader.ts
+++ b/src/lib/cacheDownloader.ts
@@ -1,0 +1,27 @@
+import { getGristLabels } from '../lib/requests/getGristLabels'
+import { getGristRecords } from '../lib/requests/getGristRecords'
+import { getGristTexts } from '../lib/requests/getGristTexts'
+import {
+  createDirectoriesIfNotAlreadyThere,
+  writeJsonFile,
+} from '../lib/scriptUtils'
+
+export async function downloadCacheData(): Promise<void> {
+  console.log(`DOWNLOADING CACHE DATA`)
+  const [texts, records, labels] = await Promise.all([
+    getGristTexts(),
+    getGristRecords(),
+    getGristLabels(),
+  ])
+  console.log(`  -> ✅ Success`)
+
+  await createDirectoriesIfNotAlreadyThere('data')
+
+  console.log(`SAVING CACHE DATA`)
+  await Promise.all([
+    writeJsonFile(`data/texts.json`, texts),
+    writeJsonFile(`data/records.json`, records),
+    writeJsonFile(`data/labels.json`, labels),
+  ])
+  console.log(`  -> ✅ Success`)
+}

--- a/src/lib/loadCacheData.ts
+++ b/src/lib/loadCacheData.ts
@@ -1,0 +1,20 @@
+import { GristLabelType, TableRowType } from '../common/types/gristData'
+import { loadJson } from './scriptUtils'
+import { TextsMapType } from './TextsContext'
+
+export async function loadCacheData(): Promise<{
+  records: TableRowType[]
+  labels: GristLabelType[]
+  texts: TextsMapType
+}> {
+  const [records, labels, texts] = await Promise.all([
+    loadJson<TableRowType[]>(`data/records.json`),
+    loadJson<GristLabelType[]>(`data/labels.json`),
+    loadJson<TextsMapType>(`data/texts.json`),
+  ])
+  return {
+    records,
+    labels,
+    texts,
+  }
+}

--- a/src/lib/loadData.ts
+++ b/src/lib/loadData.ts
@@ -1,0 +1,30 @@
+import { GristLabelType, TableRowType } from '../common/types/gristData'
+import { loadCacheData } from './loadCacheData'
+import { getGristLabels } from './requests/getGristLabels'
+import { getGristRecords } from './requests/getGristRecords'
+import { getGristTexts } from './requests/getGristTexts'
+import { TextsMapType } from './TextsContext'
+
+export async function loadData(): Promise<{
+  records: TableRowType[]
+  labels: GristLabelType[]
+  texts: TextsMapType
+}> {
+  let texts, records, labels
+  if (process.env.IS_BUILDING) {
+    const cacheData = await loadCacheData()
+    texts = cacheData.texts
+    labels = cacheData.labels
+    records = cacheData.records
+  } else {
+    const fetchedData = await Promise.all([
+      getGristTexts(),
+      getGristRecords(),
+      getGristLabels(),
+    ])
+    texts = fetchedData[0]
+    records = fetchedData[1]
+    labels = fetchedData[2]
+  }
+  return { texts, labels, records }
+}

--- a/src/lib/requests/getGristTableData.ts
+++ b/src/lib/requests/getGristTableData.ts
@@ -1,8 +1,11 @@
+import fetch from 'node-fetch'
+
 export async function getGristTableData<ResponseType = unknown>(
   docId: string,
   table: string
 ): Promise<ResponseType> {
-  const response = await fetch(
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  const response = (await fetch(
     `${
       process.env.NEXT_SECRET_GRIST_DOMAIN || ''
     }/api/docs/${docId}/tables/${table}/records`,
@@ -11,7 +14,7 @@ export async function getGristTableData<ResponseType = unknown>(
         Authorization: `Bearer ${process.env.NEXT_SECRET_GRIST_API_KEY || ''}`,
       },
     }
-  )
+  )) as unknown as Response
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`)
   }

--- a/src/lib/scriptUtils.ts
+++ b/src/lib/scriptUtils.ts
@@ -1,0 +1,27 @@
+import fsSync from 'node:fs'
+import fs from 'node:fs/promises'
+
+export const createDirectoriesIfNotAlreadyThere = async (
+  path: string
+): Promise<void> => {
+  const dirExists = fsSync.existsSync(path)
+  if (!dirExists) {
+    await fs.mkdir(path, { recursive: true })
+  }
+}
+
+export const writeJsonFile = async <T = unknown>(
+  path: string,
+  content: Record<string, T> | Record<string, T>[]
+): Promise<void> => {
+  const jsonString = JSON.stringify(content, null, 2)
+  await fs.writeFile(path, jsonString, 'utf-8')
+}
+
+export async function loadJson<
+  T = Record<string, unknown> | Record<string, unknown>[]
+>(pathToFile: string): Promise<T> {
+  const file = await fs.readFile(pathToFile, 'utf-8')
+  const json = (await JSON.parse(file)) as T
+  return json
+}

--- a/src/scripts/downloadCacheData.ts
+++ b/src/scripts/downloadCacheData.ts
@@ -1,0 +1,5 @@
+import { downloadCacheData } from '../lib/cacheDownloader'
+import * as dotenv from 'dotenv'
+dotenv.config()
+
+void downloadCacheData()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
       ]
     },
     "moduleResolution": "node",
-    "incremental": true
+    "incremental": true,
   },
   "include": [
     "next-env.d.ts",
@@ -51,5 +51,12 @@
     "*.config.js",
     ".prettierrc.js",
     "i18n.js"
-  ]
+  ],
+  "ts-node": {
+    "compilerOptions": {
+      "target": "es2019",
+      "lib": ["es2019"],
+      "module": "Node16",
+    }
+  }
 }


### PR DESCRIPTION
This PR downloads all the data initially on build time as json and uses this to render the pages statically. This avoids getting _429 too many requests_ responses. Then, if the data changes, the revalidate of nextjs executes and it fetches the real data, not the jsons.

#42 should be merged before this branch.

A great little hack! :)