### PR TITLE
feat(WEG-61): sort facilities by user geolocation

### DIFF
--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -10,6 +10,8 @@ import { GristLabelType } from '@common/types/gristData'
 import { useUrlState } from '@lib/UrlStateContext'
 import { useRouter } from 'next/router'
 import { loadData } from '@lib/loadData'
+import { useDistanceToUser } from '@lib/hooks/useDistanceToUser'
+import { useCallback } from 'react'
 
 export const getStaticProps: GetStaticProps = async () => {
   const { texts, labels, records } = await loadData()
@@ -39,6 +41,30 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
   const [urlState, setUrlState] = useUrlState()
   const texts = useTexts()
   const { isFallback } = useRouter()
+  const { getDistanceToUser } = useDistanceToUser()
+
+  const sortFacilities = useCallback(
+    (facilities: MinimalRecordType[]): MinimalRecordType[] => {
+      return facilities.sort((a, b) => {
+        const distanceToUserFromFacilityA = getDistanceToUser({
+          latitude: a.latitude,
+          longitude: a.longitude,
+        })
+        const distanceToUserFromFacilityB = getDistanceToUser({
+          latitude: b.latitude,
+          longitude: b.longitude,
+        })
+
+        // When we don't have a user geolocation we simply skip the sorting:
+        if (!distanceToUserFromFacilityA || !distanceToUserFromFacilityB)
+          return 0
+
+        return distanceToUserFromFacilityA - distanceToUserFromFacilityB
+      })
+    },
+    [getDistanceToUser]
+  )
+
   const records = originalRecords || []
 
   const filteredRecords =
@@ -47,6 +73,9 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
           urlState.tags?.every((t) => record.labels.find((l) => l === t))
         )
       : records
+
+  const filteredAndSortedRecords = sortFacilities(filteredRecords)
+
   return (
     <>
       <Head>
@@ -66,18 +95,18 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
       </h1>
       <ul>
         {!isFallback &&
-          (filteredRecords.length !== records.length ||
-            filteredRecords.length === 0) && (
+          (filteredAndSortedRecords.length !== records.length ||
+            filteredAndSortedRecords.length === 0) && (
             <div className="text-lg p-5 border-y border-gray-20 bg-gray-10/50">
               <p>
-                {filteredRecords.length === 0 && texts.noResults}
-                {filteredRecords.length === 1 &&
+                {filteredAndSortedRecords.length === 0 && texts.noResults}
+                {filteredAndSortedRecords.length === 1 &&
                   texts.filteredResultsAmountSingular
-                    .replace('#number', `${filteredRecords.length}`)
+                    .replace('#number', `${filteredAndSortedRecords.length}`)
                     .replace('#total', `${records.length}`)}
-                {filteredRecords.length > 1 &&
+                {filteredAndSortedRecords.length > 1 &&
                   texts.filteredResultsAmountPlural
-                    .replace('#number', `${filteredRecords.length}`)
+                    .replace('#number', `${filteredAndSortedRecords.length}`)
                     .replace('#total', `${records.length}`)}
               </p>
               <button
@@ -93,7 +122,7 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
               </button>
             </div>
           )}
-        {filteredRecords.map((record) => (
+        {filteredAndSortedRecords.map((record) => (
           <FacilityListItem key={record.id} {...record} />
         ))}
       </ul>

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -18,13 +18,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const recordsWithOnlyMinimum = records.map(mapRecordToMinimum)
   return {
     props: {
-      texts: {
-        ...texts,
-        mapPageTitle: texts.mapPageTitle.replace(
-          '#number',
-          `${records.length}`
-        ),
-      },
+      texts,
       records: recordsWithOnlyMinimum,
       labels,
     },
@@ -82,7 +76,10 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
         <title>
           {isFallback
             ? 'Seite Lädt...'
-            : `${texts.mapPageTitle} – ${texts.siteTitle}`}
+            : `${texts.mapPageTitle.replace(
+                '#number',
+                `${filteredAndSortedRecords.length}`
+              )} – ${texts.siteTitle}`}
         </title>
       </Head>
       <h1
@@ -91,7 +88,12 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
           `px-5 py-8 bg-white border-b border-gray-10`
         )}
       >
-        {isFallback ? `Seite Lädt...` : texts.mapPageTitle}
+        {isFallback
+          ? `Seite Lädt...`
+          : texts.mapPageTitle.replace(
+              '#number',
+              `${filteredAndSortedRecords.length}`
+            )}
       </h1>
       <ul>
         {!isFallback &&

--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -44,13 +44,15 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
   const [urlState] = useUrlState()
   const texts = useTexts()
   const isOpened = useIsFacilityOpened(mapRecordToMinimum(facility))
-  const { distance } = useDistanceToUser({
-    latitude: facility.fields.lat,
-    longitude: facility.fields.long2,
-  })
+  const { getDistanceToUser } = useDistanceToUser()
   const { allLabels, topicsLabels, targetAudienceLabels } = useRecordLabels(
     facility.fields.Schlagworte
   )
+
+  const distance = getDistanceToUser({
+    latitude: facility.fields.lat,
+    longitude: facility.fields.long2,
+  })
 
   const renderLabel = getLabelRenderer({
     activeFilters: urlState.tags || [],

--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -44,7 +44,7 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
   const [urlState] = useUrlState()
   const texts = useTexts()
   const isOpened = useIsFacilityOpened(mapRecordToMinimum(facility))
-  const distance = useDistanceToUser({
+  const { distance } = useDistanceToUser({
     latitude: facility.fields.lat,
     longitude: facility.fields.long2,
   })

--- a/src/components/FacilityListItem.tsx
+++ b/src/components/FacilityListItem.tsx
@@ -19,14 +19,16 @@ export const FacilityListItem: FC<FacilityListItemPropsType> = ({
   const [urlState] = useUrlState()
   const { id, title, latitude, longitude, labels } = record
   const texts = useTexts()
-  const { distance } = useDistanceToUser({
-    latitude,
-    longitude,
-  })
+  const { getDistanceToUser } = useDistanceToUser()
   const isOpened = useIsFacilityOpened(record)
 
   const { allLabels, topicsLabels, targetAudienceLabels } =
     useRecordLabels(labels)
+
+  const distance = getDistanceToUser({
+    latitude,
+    longitude,
+  })
 
   return (
     <li className={classNames(className)}>

--- a/src/components/FacilityListItem.tsx
+++ b/src/components/FacilityListItem.tsx
@@ -19,7 +19,7 @@ export const FacilityListItem: FC<FacilityListItemPropsType> = ({
   const [urlState] = useUrlState()
   const { id, title, latitude, longitude, labels } = record
   const texts = useTexts()
-  const distance = useDistanceToUser({
+  const { distance } = useDistanceToUser({
     latitude,
     longitude,
   })

--- a/src/lib/hooks/useDistanceToUser.ts
+++ b/src/lib/hooks/useDistanceToUser.ts
@@ -7,7 +7,9 @@ interface PointType {
   longitude?: number
 }
 
-export const useDistanceToUser = (pointA: PointType): number | undefined => {
+export const useDistanceToUser = (
+  pointA: PointType
+): { distance: number | undefined } => {
   const pointB = useUserGeolocation()
   const [distance, setDistance] = useState<number | undefined>()
   useEffect(() => {
@@ -21,5 +23,5 @@ export const useDistanceToUser = (pointA: PointType): number | undefined => {
     setDistance(Math.round(dist / 100) / 10)
   }, [pointA, pointB])
 
-  return distance
+  return { distance }
 }

--- a/src/lib/hooks/useDistanceToUser.ts
+++ b/src/lib/hooks/useDistanceToUser.ts
@@ -1,27 +1,33 @@
-import { useUserGeolocation } from './useUserGeolocation'
 import { LngLat } from 'maplibre-gl'
-import { useEffect, useState } from 'react'
+import { useCallback } from 'react'
+import { useUserGeolocation } from './useUserGeolocation'
 
 interface PointType {
   latitude?: number
   longitude?: number
 }
 
-export const useDistanceToUser = (
-  pointA: PointType
-): { distance: number | undefined } => {
+interface UseDistanceToUserReturnType {
+  getDistanceToUser: (pointA: PointType) => number | undefined
+}
+
+export const useDistanceToUser = (): UseDistanceToUserReturnType => {
   const pointB = useUserGeolocation()
-  const [distance, setDistance] = useState<number | undefined>()
-  useEffect(() => {
-    if (!pointA?.latitude || !pointA?.longitude) return
-    if (!pointB?.latitude || !pointB?.longitude) return
 
-    const userLocation = new LngLat(pointA.longitude, pointA.latitude)
-    const facilityLocation = new LngLat(pointB.longitude, pointB.latitude)
-    const dist = userLocation.distanceTo(facilityLocation)
+  const getDistanceToUser = useCallback(
+    (pointA: PointType): number | undefined => {
+      if (!pointA?.latitude || !pointA?.longitude) return
+      if (!pointB?.latitude || !pointB?.longitude) return
 
-    setDistance(Math.round(dist / 100) / 10)
-  }, [pointA, pointB])
+      const userLocation = new LngLat(pointA.longitude, pointA.latitude)
+      const facilityLocation = new LngLat(pointB.longitude, pointB.latitude)
+      const dist = userLocation.distanceTo(facilityLocation)
 
-  return { distance }
+      const distance = Math.round(dist / 100) / 10
+      return distance
+    },
+    [pointB.latitude, pointB.longitude]
+  )
+
+  return { getDistanceToUser }
 }


### PR DESCRIPTION
This PR creates a sorting for the facilities list if the user has enabled geolocation access. Close facilities are now listed higher than far ones.

---

- [x] basic implementation
- [x] make sure that number of facilities is updated in HTML title and h1
- [ ] figure out why it keeps asking for geolocation access when it was allowed but not set to remember this (in Firefox) (-> I realized that is has actually started happening before this PR)
- [ ] make sure that sorting happens without further interaction after allowing geolocation access (~~maybe related to point above~~)
- [x] update text in backend