### PR TITLE
chore(WEG-83): update Grist column names

### DIFF
--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -28,7 +28,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       records: minimalRecords,
       record,
       labels,
-      center: [record.fields.long2, record.fields.lat],
+      center: [record.fields.long, record.fields.lat],
     },
     revalidate: 120,
   }

--- a/src/common/types/gristData.ts
+++ b/src/common/types/gristData.ts
@@ -4,7 +4,7 @@ export interface GristLabelType extends Record<string, unknown> {
     key: string
     text: string
     icon: string
-    group: 'gruppe-1' | 'gruppe-2' | 'gruppe-3' | 'zielpublikum'
+    group2: 'gruppe-1' | 'gruppe-2' | 'gruppe-3' | 'zielpublikum'
   }
 }
 
@@ -54,6 +54,6 @@ export interface TableRowType extends Record<string, unknown> {
     Anmeldung_gewunscht: string
     Weitere_Offnungszeiten: string
     lat: number
-    long2: number
+    long: number
   }
 }

--- a/src/components/FacilityInfo/FacilityInfo.test.tsx
+++ b/src/components/FacilityInfo/FacilityInfo.test.tsx
@@ -46,7 +46,7 @@ const FACILITY: FacilityType = {
     Anmeldung_gewunscht: 'string',
     Weitere_Offnungszeiten: 'string',
     lat: 52.13245,
-    long2: 13.5123,
+    long: 13.5123,
   },
 }
 

--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -46,7 +46,7 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
   const isOpened = useIsFacilityOpened(mapRecordToMinimum(facility))
   const distance = useDistanceToUser({
     latitude: facility.fields.lat,
-    longitude: facility.fields.long2,
+    longitude: facility.fields.long,
   })
   const { allLabels, topicsLabels, targetAudienceLabels } = useRecordLabels(
     facility.fields.Schlagworte

--- a/src/components/FiltersList.tsx
+++ b/src/components/FiltersList.tsx
@@ -18,11 +18,11 @@ export const FiltersList: FC<{
   const { useGeolocation, setGeolocationUsage, geolocationIsForbidden } =
     useUserGeolocation()
 
-  const group1 = labels.filter(({ fields }) => fields.group === 'gruppe-1')
-  const group2 = labels.filter(({ fields }) => fields.group === 'gruppe-2')
-  const group3 = labels.filter(({ fields }) => fields.group === 'gruppe-3')
+  const group1 = labels.filter(({ fields }) => fields.group2 === 'gruppe-1')
+  const group2 = labels.filter(({ fields }) => fields.group2 === 'gruppe-2')
+  const group3 = labels.filter(({ fields }) => fields.group2 === 'gruppe-3')
   const targetGroups = labels.filter(
-    ({ fields }) => fields.group === 'zielpublikum'
+    ({ fields }) => fields.group2 === 'zielpublikum'
   )
   const someTargetFiltersActive = targetGroups.some((targetGroup) =>
     tags.find((f) => f === targetGroup.id)
@@ -59,7 +59,7 @@ export const FiltersList: FC<{
             updateFilters(
               tags.filter((f) => {
                 const label = labels.find(({ id }) => id === f)
-                return label?.fields.group !== `zielpublikum`
+                return label?.fields.group2 !== `zielpublikum`
               }) || []
             )
           }

--- a/src/lib/hooks/useRecordLabels.ts
+++ b/src/lib/hooks/useRecordLabels.ts
@@ -15,10 +15,10 @@ export const useRecordLabels = (
     .map((lId) => labelsWithData.find((l) => l.id === lId))
     .filter(Boolean) as GristLabelType[]
   const topicsLabels = recordLabels.filter(
-    ({ fields }) => fields.group !== 'zielpublikum'
+    ({ fields }) => fields.group2 !== 'zielpublikum'
   )
   const targetAudienceLabels = recordLabels.filter(
-    ({ fields }) => fields.group === 'zielpublikum'
+    ({ fields }) => fields.group2 === 'zielpublikum'
   )
 
   return {

--- a/src/lib/mapRecordToMinimum.ts
+++ b/src/lib/mapRecordToMinimum.ts
@@ -20,7 +20,7 @@ export const mapRecordToMinimum = (record: TableRowType): MinimalRecordType => {
     id: record.id,
     title: record.fields.Einrichtung,
     latitude: record.fields.lat,
-    longitude: record.fields.long2,
+    longitude: record.fields.long,
     ...getRecordOpeningTimesBounds(record.fields),
     labels: record.fields.Schlagworte,
     open247: record.fields['c24_h_7_Tage'] === 'ja',


### PR DESCRIPTION
## Attention: This change will require you to change your environment variables locally as well as in the Vercel deployment

Our new Grist instance has different column names: `long2` becomes `long`, which is better.

But `group` has to become `group2` because Grist doesn't allow changing the column ID manually in the new instance.