### PR TITLE
ci: Replaces deprecated set output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Read .nvmrc
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        id: nvm
+      - name: Set nvmrc version as .env variable
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
       - name: Use Node.js (.nvmrc)
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version: "${{ env.NODE_VERSION }}"
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run lint


### PR DESCRIPTION
The GitHub actions commands set-output and set-state will be deprecated
see this blog post --> https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/