### PR TITLE
fix(WEG-94): darken hover state of active tags

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -24,10 +24,12 @@ export const Label: FC<{
         className={classNames(
           className,
           `py-1.5 border text-lg flex gap-2 text-left leading-6 pl-2 pr-3 group`,
-          isActive && isInteractive && `bg-red border-red text-white`,
+          isActive &&
+            isInteractive &&
+            `bg-red border-red text-white hover:bg-gray-60 hover:border-gray-60`,
           (!isActive || !isInteractive) && ` border-gray-20`,
+          !isActive && isInteractive && 'hover:bg-gray-10',
           isInteractive && [
-            `hover:bg-gray-10`,
             `focus:outline-none focus:ring-2 focus:ring-red`,
             `focus:ring-offset-2 focus:ring-offset-white`,
           ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,8 @@ module.exports = {
         '10': '#EFEFEF',
         '20': '#CCCCCC',
         '40': '#999999',
+        '60': '#666666',
+        '80': '#333333',
       },
       white: '#fff',
       trasparent: 'transparent',
@@ -43,5 +45,8 @@ module.exports = {
       },
     },
   },
-  plugins: [require('@tailwindcss/line-clamp'), require('@tailwindcss/typography')],
+  plugins: [
+    require('@tailwindcss/line-clamp'),
+    require('@tailwindcss/typography'),
+  ],
 }


### PR DESCRIPTION
This PR makes sure that the hover state of (red) tags is readable by making the hover background color dark gray.