### PR TITLE
feat(FacilityInfo): break long titles with German hyphens

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from 'next/document'
 
 export default function Document(): JSX.Element {
   return (
-    <Html>
+    <Html lang="de">
       <Head>
         <link
           href="https://unpkg.com/maplibre-gl@2.1.6/dist/maplibre-gl.css"

--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -92,7 +92,9 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
       <BackButton href={{ pathname: `/map`, query: { ...urlState } }} />
       <article className="h-full flex flex-col gap-8">
         <div className="px-5 pt-5">
-          <h1 className="mb-2">{facility.fields.Einrichtung}</h1>
+          <h1 className="mb-2 text-3xl normal-case break-words hyphens-auto">
+            {facility.fields.Einrichtung}
+          </h1>
           {(distance || isOpened) && (
             <div className="flex gap-4 text-lg">
               {isOpened && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -33,3 +33,9 @@
 		@apply relative w-full h-full focus-within:outline-none focus-within:border-2 focus-within:border-red;
 	}
 }
+
+@layer utilities {
+  .hyphens-auto {
+    hyphens: auto;
+  }
+}


### PR DESCRIPTION
This PR makes sure that long titles in the facility page are breaking to new lines using hyphens. Note that this requires a custom Tailwind utility and setting the HTML language to whatever language you want the hyphens to use.