### PR TITLE
refactor(WEG-122): Make focused active buttons hover red as well

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -18,7 +18,7 @@ export const Label: FC<{
 }) => {
   const Icon = icons[label.fields.icon as keyof typeof icons] || Fragment
   return (
-    <li key={label.id} className="inline-block">
+    <li key={label.id} className="inline-block group">
       <button
         onClick={() => onClick(label.id)}
         className={classNames(
@@ -26,7 +26,7 @@ export const Label: FC<{
           `py-1.5 border text-lg flex gap-2 text-left leading-6 pl-2 pr-3 group`,
           isActive &&
             isInteractive &&
-            `bg-red border-red text-white hover:bg-gray-60 hover:border-gray-60`,
+            `bg-red border-red text-white hover:bg-gray-60 focus:group-hover:bg-red hover:border-gray-60`,
           (!isActive || !isInteractive) && ` border-gray-20`,
           !isActive && isInteractive && 'hover:bg-gray-10',
           isInteractive && [


### PR DESCRIPTION
**Problem:**
When clicking on a label, it becomes active (red). But because the mouse is hovering it simultaneously, the button has the active:hover effect on it, which is grey background. It then does not look active anymore, even having just clicked on it.

**Solution:**
The grey hover effect is only applied to labels that are hovered AND are not focused. Because a button that has just been clicked automatically becomes the focus, it remains red, which avoids the confusion. 

**Demo:**

https://user-images.githubusercontent.com/2759340/202189042-75263bcd-82b8-4aa9-85cc-010e68551114.mov

