### PR TITLE
fix(WEG-124): Fix scroll container wrongly sized on mobile

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,7 +41,7 @@ const Home: Page<HomePropsType> = ({ labels, recordsWithOnlyLabels }) => {
         <div
           className={classNames(
             isMobile && showFilters ? `-translate-x-[100vw]` : ``,
-            isMobile && `w-[200vw] transition-transform grid grid-cols-2`,
+            isMobile && `w-[200vw] transition-transform`,
             !isMobile && `container mx-auto md:max-w-7xl`
           )}
         >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head'
 import classNames from '@lib/classNames'
 import { WelcomeScreen } from '@components/WelcomeScreen'
 import { WelcomeFilters } from '@components/WelcomeFilters'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { GristLabelType, TableRowType } from '@common/types/gristData'
 import { useIsMobile } from '@lib/hooks/useIsMobile'
 import { LegalFooter } from '@components/LegalFooter'
@@ -30,6 +30,14 @@ interface HomePropsType {
 const Home: Page<HomePropsType> = ({ labels, recordsWithOnlyLabels }) => {
   const [showFilters, setShowFilters] = useState(false)
   const isMobile = useIsMobile()
+
+  useEffect(() => {
+    document.body.classList.add('overflow-hidden')
+    return () => {
+      document.body.classList.remove('overflow-hidden')
+    }
+  }, [])
+
   return (
     <LabelsProvider value={labels}>
       <Head>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -37,11 +37,13 @@ const Home: Page<HomePropsType> = ({ labels, recordsWithOnlyLabels }) => {
           Willkommen - Digitaler Wegweiser Psychiatrie und Suchthilfe Berlin
         </title>
       </Head>
-      <div className="overflow-hidden">
+      <div
+        className={classNames('overflow-hidden', isMobile && 'fixed inset-0')}
+      >
         <div
           className={classNames(
             isMobile && showFilters ? `-translate-x-[100vw]` : ``,
-            isMobile && `w-[200vw] transition-transform`,
+            isMobile && `w-[200vw] transition-transform h-full`,
             !isMobile && `container mx-auto md:max-w-7xl`
           )}
         >

--- a/src/components/WelcomeFilters.tsx
+++ b/src/components/WelcomeFilters.tsx
@@ -23,8 +23,8 @@ export const WelcomeFilters: FC<{
     <>
       <div
         className={classNames(
-          'h-full md:h-auto flex flex-col overflow-y-auto',
-          isMobile && `w-1/2 float-left`
+          'h-full md:h-auto flex flex-col overflow-y-auto overflow-x-auto',
+          isMobile && `w-screen float-left`
         )}
       >
         {isMobile && <BackButton onClick={onGoBack} />}

--- a/src/components/WelcomeFilters.tsx
+++ b/src/components/WelcomeFilters.tsx
@@ -21,7 +21,12 @@ export const WelcomeFilters: FC<{
 
   return (
     <>
-      <div className="h-screen md:h-auto flex flex-col overflow-y-auto">
+      <div
+        className={classNames(
+          'h-screen md:h-auto flex flex-col overflow-y-auto',
+          isMobile && `w-1/2 float-left`
+        )}
+      >
         {isMobile && <BackButton onClick={onGoBack} />}
         <div className="px-5 md:px-8 pb-8">
           {isMobile && (

--- a/src/components/WelcomeFilters.tsx
+++ b/src/components/WelcomeFilters.tsx
@@ -23,7 +23,7 @@ export const WelcomeFilters: FC<{
     <>
       <div
         className={classNames(
-          'h-screen md:h-auto flex flex-col overflow-y-auto',
+          'h-full md:h-auto flex flex-col overflow-y-auto',
           isMobile && `w-1/2 float-left`
         )}
       >

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -18,28 +18,32 @@ export const WelcomeScreen: FC<{
   const { push } = useRouter()
   const isMobile = useIsMobile()
   return (
-    <div className={classNames(isMobile && `w-1/2 float-left`)}>
+    <div
+      className={classNames(
+        isMobile && `w-1/2 float-left overflow-y-auto h-full`
+      )}
+    >
       <div
         className={classNames(
           `grid grid-cols-1 grid-rows-[auto,auto,1fr,auto,auto,auto]`,
-          isMobile && `min-h-screen`
+          isMobile && `min-h-full`
         )}
       >
         <div>
           <section className="w-full h-32 md:h-[202px] relative">
             <Image src={introImage} layout="fill" objectFit="cover" />
-            <span className="absolute right-0 bottom-0 w-20 h-20">
+            <span className="absolute bottom-0 right-0 w-20 h-20">
               {/* eslint-disable-next-line prettier/prettier */}
               <StripesPattern aria-hidden="true" />
             </span>
           </section>
         </div>
-        <h1 className="p-5 md:px-8 pt-6 md:pt-12">{texts.homeWelcomeTitle}</h1>
-        <p className="px-5 md:px-8 bp-8 text-lg leading-snug max-w-prose md:mb-8">
+        <h1 className="p-5 pt-6 md:px-8 md:pt-12">{texts.homeWelcomeTitle}</h1>
+        <p className="px-5 text-lg leading-snug md:px-8 bp-8 max-w-prose md:mb-8">
           {texts.homeWelcomeText}
         </p>
         {isMobile && (
-          <div className="flex flex-col gap-2 p-5 pt-8">
+          <div className="flex flex-col p-5 pt-8 gap-2">
             <PrimaryButton onClick={onShowOffers}>
               {texts.findOffersButtonText}
             </PrimaryButton>

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -18,7 +18,7 @@ export const WelcomeScreen: FC<{
   const { push } = useRouter()
   const isMobile = useIsMobile()
   return (
-    <div>
+    <div className={classNames(isMobile && `w-1/2 float-left`)}>
       <div
         className={classNames(
           `grid grid-cols-1 grid-rows-[auto,auto,1fr,auto,auto,auto]`,

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -20,7 +20,8 @@ export const WelcomeScreen: FC<{
   return (
     <div
       className={classNames(
-        isMobile && `w-1/2 float-left overflow-y-auto h-full`
+        isMobile &&
+          `w-screen float-left overflow-y-auto h-full overflow-x-hidden`
       )}
     >
       <div


### PR DESCRIPTION
This PR does deactivate body scroll on homepage and sets scrolling on both containers of the two steps on mobile to avoid containers having different heights on mobile. This is tricky because IOS devices on mobile do not take in consideration the search bar height and this means it can lead to an interrupted scroll movement (first scroll down the container scroll, stop, then scroll the rest on the body, thus leaving a blank space in btw). See the before/after videos for difference in behavior:

|Before|After|
|-|-|
|<video src="https://user-images.githubusercontent.com/2759340/202411873-34bd6fcf-a0d0-4f68-8b7c-b29bd075f86d.MP4">  | <video src="https://user-images.githubusercontent.com/2759340/202411827-18cb417d-6b03-47ac-87bf-04163764edbc.MP4">|
