### PR TITLE
feat(WEG-97): Allow html tags in some texts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "12.3.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "sanitize-html": "2.7.3",
         "swiper": "8.4.3",
         "use-debounce": "8.0.4"
       },
@@ -27,6 +28,7 @@
         "@types/node": "17.0.21",
         "@types/node-fetch": "2.6.2",
         "@types/react": "17.0.50",
+        "@types/sanitize-html": "2.6.2",
         "@typescript-eslint/eslint-plugin": "5.41.0",
         "@typescript-eslint/parser": "5.41.0",
         "autoprefixer": "10.4.12",
@@ -3300,6 +3302,15 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.6.2.tgz",
+      "integrity": "sha512-7Lu2zMQnmHHQGKXVvCOhSziQMpa+R2hMHFefzbYoYMHeaXR0uXqNeOc3JeQQQ8/6Xa2Br/P1IQTLzV09xxAiUQ==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^6.0.0"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -4908,7 +4919,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5080,7 +5090,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -5102,7 +5111,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5126,7 +5134,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -5141,7 +5148,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -5228,7 +5234,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -6716,6 +6721,24 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -7134,7 +7157,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13953,6 +13975,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -14204,7 +14231,6 @@
       "version": "8.4.18",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
       "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14972,6 +14998,30 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.3.tgz",
+      "integrity": "sha512-jMaHG29ak4miiJ8wgqA1849iInqORgNv7SLfSw9LtfOhEUQ1C0YHKH73R+hgyufBW9ZFeJrb057k9hjlfBCVlw==",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -19158,6 +19208,15 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
+    "@types/sanitize-html": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.6.2.tgz",
+      "integrity": "sha512-7Lu2zMQnmHHQGKXVvCOhSziQMpa+R2hMHFefzbYoYMHeaXR0uXqNeOc3JeQQQ8/6Xa2Br/P1IQTLzV09xxAiUQ==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^6.0.0"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -20338,8 +20397,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.4",
@@ -20465,7 +20523,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -20483,8 +20540,7 @@
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domexception": {
       "version": "4.0.0",
@@ -20499,7 +20555,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.2.0"
       }
@@ -20508,7 +20563,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -20576,8 +20630,7 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "env-ci": {
       "version": "5.5.0",
@@ -21685,6 +21738,17 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
     "http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -21962,8 +22026,7 @@
     "is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -26939,6 +27002,11 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -27128,7 +27196,6 @@
       "version": "8.4.18",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
       "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
-      "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -27680,6 +27747,26 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sanitize-html": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.3.tgz",
+      "integrity": "sha512-jMaHG29ak4miiJ8wgqA1849iInqORgNv7SLfSw9LtfOhEUQ1C0YHKH73R+hgyufBW9ZFeJrb057k9hjlfBCVlw==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
     },
     "saxes": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "next": "12.3.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "sanitize-html": "2.7.3",
     "swiper": "8.4.3",
     "use-debounce": "8.0.4"
   },
   "devDependencies": {
     "@faker-js/faker": "7.6.0",
-    "@tailwindcss/typography": "0.5.7",
     "@tailwindcss/line-clamp": "0.4.2",
+    "@tailwindcss/typography": "0.5.7",
     "@technologiestiftung/semantic-release-config": "1.1.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
@@ -34,6 +35,7 @@
     "@types/node": "17.0.21",
     "@types/node-fetch": "2.6.2",
     "@types/react": "17.0.50",
+    "@types/sanitize-html": "2.6.2",
     "@typescript-eslint/eslint-plugin": "5.41.0",
     "@typescript-eslint/parser": "5.41.0",
     "autoprefixer": "10.4.12",

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -11,6 +11,7 @@ import { useEffect } from 'react'
 import { loadCacheData } from '@lib/loadCacheData'
 import { loadData } from '@lib/loadData'
 import { LngLatLike } from 'maplibre-gl'
+import sanitizeHtml from 'sanitize-html'
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const id = params?.id
@@ -26,7 +27,16 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     props: {
       texts,
       records: minimalRecords,
-      record,
+      record: {
+        ...record,
+        Uber_uns: sanitizeHtml(record.fields.Uber_uns, {
+          allowedTags: ['a', 'b', 'i', 'em', 'strong', 'u', 'sup', 'sub'],
+          allowedAttributes: {
+            a: ['href', 'title'],
+          },
+          disallowedTagsMode: 'discard',
+        }),
+      },
       labels,
       center: [record.fields.long, record.fields.lat],
     },

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -96,7 +96,7 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
       </Head>
       <h1
         className={classNames(
-          `hidden lg:block sticky top-0`,
+          `hidden lg:block sticky top-0 z-10`,
           `px-5 py-8 bg-white border-b border-gray-10`
         )}
       >

--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -120,13 +120,16 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
               {distance && <span>{distance} km</span>}
             </div>
           )}
-          <p className="mt-4">{facility.fields.Uber_uns}</p>
+          <p
+            className="mt-4"
+            dangerouslySetInnerHTML={{ __html: facility.fields.Uber_uns }}
+          />
         </div>
         {allLabels.length > 0 && (
           <div className="w-full">
             <div className="overflow-x-auto">
               {topicsLabels.length > 0 && (
-                <div className="float-left flex gap-2 p-5 whitespace-nowrap">
+                <div className="flex float-left p-5 gap-2 whitespace-nowrap">
                   {topicsLabels.map(renderLabel)}
                 </div>
               )}
@@ -137,7 +140,7 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
                   {texts.filtersSearchTargetLabelOnCard}
                 </h2>
                 <div className="overflow-x-auto">
-                  <div className="float-left flex gap-2 p-5 gap-2 pt-1 whitespace-nowrap">
+                  <div className="flex float-left p-5 pt-1 gap-2 whitespace-nowrap">
                     {targetAudienceLabels.map(renderLabel)}
                   </div>
                 </div>

--- a/src/components/WelcomeFilters.tsx
+++ b/src/components/WelcomeFilters.tsx
@@ -48,9 +48,10 @@ export const WelcomeFilters: FC<{
               </SecondaryButton>
             </h2>
           )}
-          <p className="text-lg pb-6 md:pb-0 leading-snug md:max-w-[66%]">
-            {texts.welcomeFiltersText}
-          </p>
+          <p
+            className="text-lg pb-6 md:pb-0 leading-snug md:max-w-[66%]"
+            dangerouslySetInnerHTML={{ __html: texts.welcomeFiltersText }}
+          />
           <FiltersList recordsWithOnlyLabels={recordsWithOnlyLabels} />
           <div className="hidden md:block w-full mt-6">
             <TextLink href={texts.moreOffersKVBLinkUrl}>

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -40,9 +40,10 @@ export const WelcomeScreen: FC<{
           </section>
         </div>
         <h1 className="p-5 pt-6 md:px-8 md:pt-12">{texts.homeWelcomeTitle}</h1>
-        <p className="px-5 text-lg leading-snug md:px-8 bp-8 max-w-prose md:mb-8">
-          {texts.homeWelcomeText}
-        </p>
+        <p
+          className="px-5 text-lg leading-snug md:px-8 bp-8 max-w-prose md:mb-8"
+          dangerouslySetInnerHTML={{ __html: texts.homeWelcomeText }}
+        />
         {isMobile && (
           <div className="flex flex-col p-5 pt-8 gap-2">
             <PrimaryButton onClick={onShowOffers}>

--- a/src/lib/mapRecordToMinimum.ts
+++ b/src/lib/mapRecordToMinimum.ts
@@ -1,4 +1,5 @@
 import { TableRowType } from '@common/types/gristData'
+import sanitizeHtml from 'sanitize-html'
 import {
   getRecordOpeningTimesBounds,
   OpeningTimesBoundsType,
@@ -25,6 +26,10 @@ export const mapRecordToMinimum = (record: TableRowType): MinimalRecordType => {
     ...getRecordOpeningTimesBounds(record.fields),
     labels: record.fields.Schlagworte,
     open247: record.fields['c24_h_7_Tage'].trim() === 'ja',
-    description: record.fields.Uber_uns,
+    description: sanitizeHtml(record.fields.Uber_uns, {
+      allowedTags: [],
+      allowedAttributes: {},
+      disallowedTagsMode: 'discard',
+    }),
   }
 }

--- a/src/lib/requests/getGristTexts.ts
+++ b/src/lib/requests/getGristTexts.ts
@@ -1,4 +1,5 @@
 import { TextsMapType } from '@lib/TextsContext'
+import sanitize from 'sanitize-html'
 import { getGristTableData } from './getGristTableData'
 
 export interface GristTextRecordType {
@@ -10,16 +11,26 @@ export interface GristTextRecordType {
   }
 }
 
+const keysOfAllowedHtml = ['homeWelcomeText', 'welcomeFiltersText']
+
 export async function getGristTexts(): Promise<TextsMapType> {
   const data = await getGristTableData<{ records: GristTextRecordType[] }>(
     process.env.NEXT_SECRET_GRIST_DOC_ID || '',
     process.env.NEXT_SECRET_GRIST_TEXTS_TABLE || ''
   )
-  return data.records.reduce(
-    (acc, { fields: { key, de } }) => ({
+  return data.records.reduce((acc, { fields: { key, de } }) => {
+    const htmlIsAllowed = !!keysOfAllowedHtml.find((k) => k === key)
+    return {
       ...acc,
-      [key]: de,
-    }),
-    {}
-  ) as TextsMapType
+      [key]: sanitize(de, {
+        allowedTags: htmlIsAllowed
+          ? ['a', 'b', 'i', 'em', 'strong', 'u', 'sup', 'sub']
+          : [],
+        allowedAttributes: {
+          a: htmlIsAllowed ? ['href', 'title'] : [],
+        },
+        disallowedTagsMode: 'discard',
+      }),
+    }
+  }, {}) as TextsMapType
 }


### PR DESCRIPTION
This PR adds the ability to use some HTML tags to format some texts within grist. For now, this is enabled only for some specific texts:
- Home welcome text
- Home filters intro text
- Facility info (Only in individual page, as shortening texts with HTML using ellipsis can cause problems)  

In all other texts the HTML is either escaped (as until now) or stripped aways.

We currently only allow a certain amount of tags for formatting only. This avoid people trying to fit iframes, list, and whatnot into the texts. These are the currently supported HTML tags. @dnsos & @Esshahn please let me know if you think we should support other tags:
```
['a', 'b', 'i', 'em', 'strong', 'u', 'sup', 'sub']
```