### PR TITLE
refactor(WEG-146): Refactor map file to smaller hooks for better adaptation and maintenance in the future

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,11 +1,5 @@
-import { useEffect, FC, useRef, useState, useCallback } from 'react'
-import maplibregl, {
-  DataDrivenPropertyValueSpecification,
-  LngLatLike,
-  Map,
-  Marker,
-  Popup,
-} from 'maplibre-gl'
+import { useEffect, FC, useRef, useCallback } from 'react'
+import { DataDrivenPropertyValueSpecification } from 'maplibre-gl'
 import {
   createGeoJsonStructure,
   GeojsonFeatureType,

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, FC, useRef, useCallback } from 'react'
-import { DataDrivenPropertyValueSpecification } from 'maplibre-gl'
+import { DataDrivenPropertyValueSpecification, Popup } from 'maplibre-gl'
 import {
   createGeoJsonStructure,
   GeojsonFeatureType,

--- a/src/components/MapLayout.tsx
+++ b/src/components/MapLayout.tsx
@@ -11,7 +11,6 @@ import { useUrlState } from '@lib/UrlStateContext'
 import { useTexts } from '@lib/TextsContext'
 import { MapListSwitch } from './MapListSwitch'
 import { Cross } from './icons/Cross'
-import { LngLatLike } from 'maplibre-gl'
 import { FacilityCarousel } from './FacilityCarousel'
 import { MapHeader } from './MapHeader'
 import { MapButtons } from './MapButtons'
@@ -28,8 +27,12 @@ export const MapLayout: FC<{
   const { query, pathname, isFallback } = useRouter()
   const texts = useTexts()
   const [listViewOpen, setListViewOpen] = useState<boolean>(false)
-  const [mapCenter, setMapCenter] = useState<LngLatLike | undefined>()
-  const [searchCenter, setSearchCenter] = useState<LngLatLike | undefined>()
+  const [mapCenter, setMapCenter] = useState<
+    [lng: number, lat: number] | undefined
+  >()
+  const [searchCenter, setSearchCenter] = useState<
+    [lng: number, lat: number] | undefined
+  >()
   const [selectedFacilities, setSelectedFacilities] = useState<
     MinimalRecordType[]
   >([])

--- a/src/lib/hooks/useEaseOnBackToMap.ts
+++ b/src/lib/hooks/useEaseOnBackToMap.ts
@@ -1,0 +1,53 @@
+import { normalizeLatLng } from '@components/Map/mapUtil'
+import { ViewportType } from '@lib/types/map'
+import { Map } from 'maplibre-gl'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { usePreviousViewport } from './usePreviousViewport'
+
+interface InputType {
+  map: Map | null
+  zoomedInCoords: Partial<ViewportType> | null
+}
+
+export function useEaseOnBackToMap({ map, zoomedInCoords }: InputType): void {
+  const { pathname } = useRouter()
+  const prevViewport = usePreviousViewport(map)
+
+  useEffect(() => {
+    if (!map) return
+
+    if (pathname !== '/map') return
+
+    // When moving from [id] to /map, we check if the position of the
+    // has changed and zoom back to the previous position in case it hasn't
+    const mapLng = normalizeLatLng(map.getCenter().lng)
+    const mapLat = normalizeLatLng(map.getCenter().lat)
+    const mapZoom = Math.round(map.getZoom())
+
+    const markerLng = normalizeLatLng(zoomedInCoords?.longitude)
+    const markerLat = normalizeLatLng(zoomedInCoords?.latitude)
+    const markerZoom = Math.round(zoomedInCoords?.zoom || 0)
+
+    const prevLng = normalizeLatLng(prevViewport.current?.longitude)
+    const prevLat = normalizeLatLng(prevViewport.current?.latitude)
+    const prevZoom = Math.round(prevViewport.current?.zoom || 0)
+
+    // When an [id] page is (re)loaded, it doesn't yet have a previous position
+    if (!prevLng || !prevLat || !prevZoom) return
+    // If the user hasn't moved from the default facility position and zoom,
+    // we zoom back to the previous map position and zoom
+    // This makes it easy to regain context and orientation
+    if (
+      mapLng === markerLng &&
+      mapLat === markerLat &&
+      mapZoom === markerZoom
+    ) {
+      map.easeTo({
+        center: [prevLng, prevLat],
+        zoom: prevZoom,
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname])
+}

--- a/src/lib/hooks/useInitialViewport.ts
+++ b/src/lib/hooks/useInitialViewport.ts
@@ -1,0 +1,57 @@
+import { ViewportType } from '@lib/types/map'
+import { useUrlState } from '@lib/UrlStateContext'
+import { Map } from 'maplibre-gl'
+import { useEffect, useState } from 'react'
+
+export function useInitialViewport(map: Map | null): void {
+  const [urlState] = useUrlState()
+  // The initial viewport will be available on 2nd render,
+  // because we get it from useRouter. First it has to be null.
+  const [initialViewport, setInitialViewport] = useState<ViewportType | null>(
+    null
+  )
+
+  useEffect(() => {
+    // If we've already got an initial viewport, we can not redefine it
+    // anymore because something initial shoudl only be set once.
+    if (initialViewport) return
+
+    if (!urlState.latitude || !urlState.longitude || !urlState.zoom) return
+
+    const mapLongitude = map?.transform._center.lng
+    const mapLatitude = map?.transform._center.lat
+    const mapZoom = map?.transform._zoom
+
+    if (
+      mapLongitude === urlState.longitude &&
+      mapLatitude === urlState.latitude &&
+      mapZoom === urlState.zoom
+    )
+      return
+
+    // If all previous checks were passed, we need to set the initial viewport,
+    // which in the useEffect below will easeTo the desired location.
+    setInitialViewport({
+      longitude: urlState.longitude,
+      latitude: urlState.latitude,
+      zoom: urlState.zoom,
+    })
+  }, [
+    map,
+    urlState.latitude,
+    urlState.longitude,
+    urlState.zoom,
+    initialViewport,
+  ])
+  //
+  // After the initial viewport has been set ONCE (in the above useEffect),
+  // we ease the map to the location specified in the query state.
+  useEffect(() => {
+    if (!initialViewport) return
+    map &&
+      map.easeTo({
+        center: [initialViewport.longitude, initialViewport.latitude],
+        zoom: initialViewport.zoom,
+      })
+  }, [map, initialViewport])
+}

--- a/src/lib/hooks/useMapHighlightMarker.ts
+++ b/src/lib/hooks/useMapHighlightMarker.ts
@@ -1,0 +1,46 @@
+import classNames from '@lib/classNames'
+import { ViewportType } from '@lib/types/map'
+import { LngLatLike, Map, Marker } from 'maplibre-gl'
+import { useEffect, useRef } from 'react'
+
+export function useMapHighlightMarker(
+  map: Map | null,
+  markerViewport: ViewportType | null
+): Marker | null {
+  const highlightedMarker = useRef<Marker>(null)
+
+  useEffect(() => {
+    if (!map) return
+    // Remove possibly existent markers:
+    highlightedMarker.current?.remove()
+
+    if (!markerViewport?.latitude) return
+    const customMarker = document.createElement('div')
+    customMarker.className = classNames(
+      'w-10 h-10 bg-red rounded-full ring-2',
+      'ring-offset-white ring-offset-2 ring-red'
+    )
+
+    const markerCenter = [
+      markerViewport.longitude,
+      markerViewport.latitude,
+    ] as LngLatLike
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    highlightedMarker.current = new Marker(customMarker)
+      .setLngLat(markerCenter)
+      .addTo(map)
+
+    map.easeTo({
+      center: markerCenter,
+      zoom: markerViewport.zoom,
+    })
+  }, [
+    map,
+    markerViewport?.longitude,
+    markerViewport?.latitude,
+    markerViewport?.zoom,
+  ])
+
+  return highlightedMarker.current
+}

--- a/src/lib/hooks/useMapIsFullyLoaded.ts
+++ b/src/lib/hooks/useMapIsFullyLoaded.ts
@@ -1,0 +1,25 @@
+import { Map } from 'maplibre-gl'
+import { useEffect, useState } from 'react'
+
+export function useMapIsFullyLoaded(map: null | Map): boolean {
+  const [mapIsFullyLoaded, setMapIsFullyLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!map) return
+
+    map.on('load', () => {
+      const pollForMapLoaded = (): void => {
+        if (map?.loaded()) {
+          setMapIsFullyLoaded(true)
+          return
+        } else {
+          requestAnimationFrame(pollForMapLoaded)
+        }
+      }
+
+      pollForMapLoaded()
+    })
+  }, [map])
+
+  return mapIsFullyLoaded
+}

--- a/src/lib/hooks/useMapSearchMarker.ts
+++ b/src/lib/hooks/useMapSearchMarker.ts
@@ -1,0 +1,46 @@
+import classNames from '@lib/classNames'
+import { ViewportType } from '@lib/types/map'
+import { LngLatLike, Map, Marker } from 'maplibre-gl'
+import { useEffect, useRef } from 'react'
+
+export function useMapSearchMarker(
+  map: Map | null,
+  searchViewport: ViewportType | null
+): void {
+  const highlightedSearchMarker = useRef<Marker>(null)
+  useEffect(() => {
+    if (!map) return
+    if (!searchViewport?.latitude) {
+      // Without a searchCenter we want to remove any highlightedSearchMarker:
+      highlightedSearchMarker && highlightedSearchMarker.current?.remove()
+      return
+    } else {
+      // Remove possibly existent markers:
+      highlightedSearchMarker.current?.remove()
+
+      const customMarker = document.createElement('div')
+      customMarker.className = classNames('w-8 h-8 bg-norepeat')
+      customMarker.style.backgroundImage = 'url("/images/search_geopin.svg")'
+
+      const searchCenter = [
+        searchViewport.longitude,
+        searchViewport.latitude,
+      ] as LngLatLike
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      highlightedSearchMarker.current = new Marker(customMarker)
+        .setLngLat(searchCenter)
+        .addTo(map)
+
+      map.easeTo({
+        center: searchCenter,
+        zoom: searchViewport.zoom,
+      })
+    }
+  }, [
+    map,
+    searchViewport?.latitude,
+    searchViewport?.longitude,
+    searchViewport?.zoom,
+  ])
+}

--- a/src/lib/hooks/useMapUserGeolocationMarker.ts
+++ b/src/lib/hooks/useMapUserGeolocationMarker.ts
@@ -1,0 +1,48 @@
+import classNames from '@lib/classNames'
+import { Map, Marker } from 'maplibre-gl'
+import { useEffect, useRef } from 'react'
+import { useUserGeolocation } from './useUserGeolocation'
+
+export function useMapUserGeolocationMarker(
+  map: Map | null,
+  zoomedInZoom?: number,
+  loaded?: boolean
+): void {
+  const {
+    isLoading: userGeolocationIsLoading,
+    latitude: userLatitude,
+    longitude: userLongitude,
+    useGeolocation,
+  } = useUserGeolocation()
+  const highlightedUserGeoposition = useRef<Marker>(null)
+
+  useEffect(() => {
+    if (!map) return
+    if (!useGeolocation || !userLatitude || !userLongitude) {
+      // Without a userGeolocation we want to remove any highlightedUserGeoposition:
+      highlightedUserGeoposition && highlightedUserGeoposition.current?.remove()
+      return
+    } else {
+      // Remove possibly existent user geoposition marker:
+      highlightedUserGeoposition.current?.remove()
+
+      const customMarker = document.createElement('div')
+      customMarker.className = classNames(
+        'w-8 h-8 border-2 border-white rounded-full bg-blau ring-2',
+        'ring-blau ring-offset-2 ring-offset-white'
+      )
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      highlightedUserGeoposition.current = new Marker(customMarker)
+        .setLngLat([userLongitude, userLatitude])
+        .addTo(map)
+
+      map.easeTo({
+        center: [userLongitude, userLatitude],
+        zoom: zoomedInZoom || 17,
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded, userGeolocationIsLoading, useGeolocation])
+}

--- a/src/lib/hooks/useMaplibreMap.ts
+++ b/src/lib/hooks/useMaplibreMap.ts
@@ -1,0 +1,31 @@
+import { LngLatLike, Map } from 'maplibre-gl'
+import { useEffect, useRef } from 'react'
+
+export function useMaplibreMap(config: {
+  containerId: string
+  defaultLatitude: number
+  defaultLongitude: number
+  defaultZoom: number
+  maxZoom: number
+  minZoom: number
+}): Map | null {
+  const map = useRef<Map>(null)
+  // Map setup (run only once on initial render)
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    map.current = new Map({
+      container: config.containerId,
+      style: `${process.env.NEXT_PUBLIC_MAPTILER_STYLE_URL || ''}?key=${
+        process.env.NEXT_PUBLIC_MAPTILER_API_KEY || ''
+      }`,
+      center: [config.defaultLongitude, config.defaultLatitude] as LngLatLike,
+      zoom: config.defaultZoom,
+      minZoom: config.minZoom,
+      maxZoom: config.maxZoom,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return map.current
+}

--- a/src/lib/hooks/useOnMapFeatureMove.ts
+++ b/src/lib/hooks/useOnMapFeatureMove.ts
@@ -1,0 +1,27 @@
+import { GeojsonFeatureType } from '@lib/createGeojsonStructure'
+import { MinimalRecordType } from '@lib/mapRecordToMinimum'
+import { Map } from 'maplibre-gl'
+import { useEffect } from 'react'
+
+type HandlerType = (features: GeojsonFeatureType<MinimalRecordType>[]) => void
+
+export function useOnMapFeatureMove(
+  map: Map | null,
+  layer: string,
+  handler: HandlerType
+): void {
+  useEffect(() => {
+    if (!map) return
+
+    map.on('load', () => {
+      if (layer && handler) {
+        map.on('mousemove', layer, (e) => {
+          if (!map || !handler) return
+          if (!e.features || e.features.length === 0) return
+          const features = e.features as GeojsonFeatureType<MinimalRecordType>[]
+          handler(features)
+        })
+      }
+    })
+  }, [map, handler, layer])
+}

--- a/src/lib/hooks/usePreviousViewport.ts
+++ b/src/lib/hooks/usePreviousViewport.ts
@@ -1,0 +1,28 @@
+import { ViewportType } from '@lib/types/map'
+import { Map } from 'maplibre-gl'
+import { RefObject, useEffect, useRef } from 'react'
+
+export function usePreviousViewport(map: Map | null): RefObject<ViewportType> {
+  const prevViewport = useRef<ViewportType>(null)
+
+  useEffect(() => {
+    if (!map) return
+    map.on('moveend', (e) => {
+      // Determines whether a moveend event has been triggered by a user or
+      // a programatic change (easeTo, flyTo, etc)
+      const isUserEvent = !!e.originalEvent
+      if (!map || !isUserEvent) return
+      // If the user has changed the zoom or position, we save a reference
+      // to the last position/zoom in order to move back to this position
+      // when the user goes back to map overview (deselcts the facility)
+      const { lat: latitude, lng: longitude } = map.getCenter()
+      const zoom = map.getZoom.bind(map)()
+      if (!latitude || !longitude || !zoom) return
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      prevViewport.current = { latitude, longitude, zoom }
+    })
+  }, [map])
+
+  return prevViewport
+}

--- a/src/lib/types/map.ts
+++ b/src/lib/types/map.ts
@@ -1,4 +1,4 @@
-export type ViewportProps = Partial<{
+interface FullViewportType {
   width: number
   height: number
   latitude: number
@@ -15,9 +15,16 @@ export type ViewportProps = Partial<{
   transitionEasing: (t: number) => number
   transitionInterpolator: unknown
   transitionInterruption: number
-}>
+}
+
+export type ViewportProps = Partial<FullViewportType>
 
 export type URLViewportType = Pick<
   ViewportProps,
+  'latitude' | 'longitude' | 'zoom'
+>
+
+export type ViewportType = Pick<
+  FullViewportType,
   'latitude' | 'longitude' | 'zoom'
 >


### PR DESCRIPTION
This PR ensures the map is easier to maintain and adapt in the future by extracting generic business logic into meaningful react hooks. This can be improved even further in the future but this is a good first step. The different hooks are:
- useEaseOnBackToMap (To easing back the the previous location when navigating back to the map overview)
- useMapIsFullyLoaded (To poll for the map styles to load)
- useOnMapFeatureMove (To hover on markers)
- useMapUserGeolocationMarker (To ease to the user's geolocation when activating the geolocation)
- useInitialViewport (To manage the initial viewport based on the url parameters)
- useMapHighlightMarker (To add/remove the active marker on facility pages)
- useMapSearchMarker (To add/remove the search marker)
- useMaplibreMap (To init the map instance)