### PR TITLE
feat(WEG-114): Sort by priority first and then by title or distance

### DIFF
--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -16,7 +16,11 @@ import { useUserGeolocation } from '@lib/hooks/useUserGeolocation'
 
 export const getStaticProps: GetStaticProps = async () => {
   const { texts, labels, records } = await loadData()
-  const recordsWithOnlyMinimum = records.map(mapRecordToMinimum)
+  const recordsWithOnlyMinimum = records
+    .map(mapRecordToMinimum)
+    .filter((r) => r.prioriy >= 0)
+    .sort((a, b) => b.prioriy - a.prioriy || a.title.localeCompare(b.title))
+
   return {
     props: {
       texts: {
@@ -63,9 +67,12 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
 
         // When we don't have a user geolocation we simply skip the sorting:
         if (!distanceToUserFromFacilityA || !distanceToUserFromFacilityB)
-          return 0
+          return b.prioriy - a.prioriy
 
-        return distanceToUserFromFacilityA - distanceToUserFromFacilityB
+        return (
+          b.prioriy - a.prioriy ||
+          distanceToUserFromFacilityA - distanceToUserFromFacilityB
+        )
       })
     },
     [getDistanceToUser, useGeolocation]

--- a/scripts/createFakeGristData.ts
+++ b/scripts/createFakeGristData.ts
@@ -65,6 +65,9 @@ const fakeData: Omit<TableRowType, 'id'>[] = Array.from(Array(300)).map(() => {
         getRandomNumberInRange(1, 6)
       ).map((id) => parseInt(id)),
       Zielgruppen: 'Familien;Senioren',
+      Prio: ['', 'Versteckt', 'Niedrieg', 'Mittel', 'Hoch'][
+        getRandomNumberInRange(0, 4)
+      ],
       Sprachen: createRandomArrayFromArray(
         ['Deutsch', 'Englisch', 'Türkisch', 'Polnisch', 'Arabisch', 'Spanisch'],
         getRandomNumberInRange(1, 6)
@@ -103,5 +106,7 @@ const postRows = async (): Promise<void> => {
 try {
   void postRows()
 } catch (error) {
+  console.error(error)
+}
   console.error(error)
 }

--- a/scripts/createFakeGristData.ts
+++ b/scripts/createFakeGristData.ts
@@ -108,5 +108,3 @@ try {
 } catch (error) {
   console.error(error)
 }
-  console.error(error)
-}

--- a/src/common/types/gristData.ts
+++ b/src/common/types/gristData.ts
@@ -24,6 +24,7 @@ export interface TableRowType extends Record<string, unknown> {
     Schlagworte: number[]
     /** Zielgruppen is a) still unused and b) currently a text column, which will soon become a reference list like Schlagworte */
     Zielgruppen: string
+    Prio: '' | 'Hoch' | 'Mittel' | 'Niedrieg' | 'Versteckt'
     Wichtige_Hinweise: string
     Beratungsmoglichkeiten: string
     Sprachen: string

--- a/src/lib/mapRecordToMinimum.ts
+++ b/src/lib/mapRecordToMinimum.ts
@@ -5,6 +5,8 @@ import {
   OpeningTimesBoundsType,
 } from './getRecordOpeningTimesBounds'
 
+type PrioNumberType = -1 | 0 | 1 | 2
+
 export interface MinimalRecordType
   extends Record<string, unknown>,
     OpeningTimesBoundsType {
@@ -12,6 +14,7 @@ export interface MinimalRecordType
   title: string
   latitude: number
   longitude: number
+  prioriy: PrioNumberType
   labels: number[]
   open247: boolean
   description: string
@@ -26,10 +29,26 @@ export const mapRecordToMinimum = (record: TableRowType): MinimalRecordType => {
     ...getRecordOpeningTimesBounds(record.fields),
     labels: record.fields.Schlagworte,
     open247: record.fields['c24_h_7_Tage'].trim() === 'ja',
+    prioriy: mapPriorityToNumber(record.fields.Prio),
     description: sanitizeHtml(record.fields.Uber_uns, {
       allowedTags: [],
       allowedAttributes: {},
       disallowedTagsMode: 'discard',
     }),
+  }
+}
+
+function mapPriorityToNumber(
+  rawPrio: TableRowType['fields']['Prio']
+): PrioNumberType {
+  switch (rawPrio) {
+    case 'Hoch':
+      return 2
+    case 'Mittel':
+      return 1
+    case 'Versteckt':
+      return -1
+    default:
+      return 0
   }
 }


### PR DESCRIPTION
This PR adds a Priority Option field to Grist and uses that in frontend to sort the facilities accordingly. There are 2 sort scenatiors:
1. The geolocation filter is off. Items are sorted first by priority, then by name
2. The geolocation filter is on. Items are sorted first by priority, then by distance

![CleanShot 2022-12-14 at 15 03 22](https://user-images.githubusercontent.com/2759340/207615687-260b37cc-c4b6-4f56-832f-52d78f69c14f.png)
