### PR TITLE
fix(WEG-147): Don't ease to the user's location if on a facility page

### DIFF
--- a/src/lib/hooks/useMapUserGeolocationMarker.ts
+++ b/src/lib/hooks/useMapUserGeolocationMarker.ts
@@ -1,5 +1,6 @@
 import classNames from '@lib/classNames'
 import { Map, Marker } from 'maplibre-gl'
+import { useRouter } from 'next/router'
 import { useEffect, useRef } from 'react'
 import { useUserGeolocation } from './useUserGeolocation'
 
@@ -15,6 +16,7 @@ export function useMapUserGeolocationMarker(
     useGeolocation,
   } = useUserGeolocation()
   const highlightedUserGeoposition = useRef<Marker>(null)
+  const { pathname } = useRouter()
 
   useEffect(() => {
     if (!map) return
@@ -38,6 +40,7 @@ export function useMapUserGeolocationMarker(
         .setLngLat([userLongitude, userLatitude])
         .addTo(map)
 
+      if (pathname !== '/map') return
       map.easeTo({
         center: [userLongitude, userLatitude],
         zoom: zoomedInZoom || 17,


### PR DESCRIPTION
This PR ensures the map animates the view to the user's location only if the map page is loaded, not on a facility page. Otherwise it can be confusing. It can look as if the user's location is the facility location. 