### PR TITLE
feat(WEG-148): Show active element in spiderfied branches

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -18,6 +18,7 @@ import {
   getFeaturesOnSameCoordsThanFirstOne,
   getSpiderfier,
   MarkerClickHandlerType,
+  ClusterClickHandlerType,
   setCursor,
   zoomIn,
 } from './mapUtil'
@@ -82,6 +83,7 @@ export const FacilitiesMap: FC<MapType> = ({
   const hoveredStateIds = useRef<number[]>(null)
   const spideredFeatureIds = useRef<number[]>(null)
   const markerClickHandler = useRef<MarkerClickHandlerType>(() => undefined)
+  const clusterClickHandler = useRef<ClusterClickHandlerType>(() => undefined)
   const [spiderifiedIds, setSpiderfiedIds] = useState<number[]>([])
   const spiderifier =
     useRef<InstanceType<typeof MaplibreglSpiderifier<MinimalRecordType>>>(null)
@@ -240,8 +242,10 @@ export const FacilitiesMap: FC<MapType> = ({
     }
   }, [setSpiderfiedIds])
 
-  const onInternalMarkerClick = useCallback(
-    (features?: GeojsonFeatureType<MinimalRecordType>[]): void => {
+  useEffect(() => {
+    clusterClickHandler.current = (
+      features?: GeojsonFeatureType<MinimalRecordType>[]
+    ): void => {
       if (!features || !markers) return
       if (!map || !spiderifier.current) return
 
@@ -299,9 +303,8 @@ export const FacilitiesMap: FC<MapType> = ({
       spideredFeatureIds.current.forEach((id) => {
         map?.setFeatureState({ source: 'facilities', id }, { spidered: true })
       })
-    },
-    [query.id, markers, map]
-  )
+    }
+  }, [query.id, markers, map])
 
   useEffect(() => {
     if (!mapStylesLoaded || !markers || !map) return
@@ -379,7 +382,7 @@ export const FacilitiesMap: FC<MapType> = ({
 
     map.on('click', 'unclustered-point', (e) => {
       const features = e.features as GeojsonFeatureType<MinimalRecordType>[]
-      onInternalMarkerClick(features)
+      clusterClickHandler.current(features)
     })
 
     map.on('mousemove', 'unclustered-point', (e) => {

--- a/src/components/Map/mapUtil.ts
+++ b/src/components/Map/mapUtil.ts
@@ -8,6 +8,9 @@ import { LngLat, Map, LngLatLike, Popup } from 'maplibre-gl'
 import { getPopupHTML } from './popupUtils'
 
 export type MarkerClickHandlerType = (facility: MinimalRecordType) => void
+export type ClusterClickHandlerType = (
+  facilites: GeojsonFeatureType<MinimalRecordType>[]
+) => void
 
 export function getSpiderfier(config: {
   popup: Popup

--- a/src/lib/MaplibreglSpiderifier.ts
+++ b/src/lib/MaplibreglSpiderifier.ts
@@ -85,7 +85,11 @@ export default class MaplibreglSpiderifier<MarkerType extends { id: number }> {
     )
   }
 
-  public spiderfy(lngLat: LngLatLike, markers: MarkerType[]): void {
+  public spiderfy(
+    lngLat: LngLatLike,
+    markers: MarkerType[],
+    activeElementId?: string
+  ): void {
     const spiderParams = this.generateSpiderParams(markers.length)
     let markerObjects: MarkerObjectType<MarkerType>[] = []
 
@@ -119,6 +123,10 @@ export default class MaplibreglSpiderifier<MarkerType extends { id: number }> {
         elements.marker.addEventListener('mouseleave', (e: Event) => {
           this.options.onMouseleave(e, markerObject)
         })
+
+        if (activeElementId === `${marker.id}`) {
+          elements.marker.classList.add('active')
+        }
 
         return markerObject
       }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,10 @@
     height: 22px;
   }
 
+  .spidered-marker .icon-div.active::before {
+    @apply ring-2 ring-red ring-offset-2 ring-offset-white;
+  }
+
   .spidered-marker:hover .icon-div::before {
     @apply bg-gray-40;
   }


### PR DESCRIPTION
This PR adds an active style to the "spiderfied" elements on an active faciliy page. The following video explains this way better than I can with words:

![spidered-active-branch](https://user-images.githubusercontent.com/2759340/208903768-5e60d642-2c89-460c-bd85-c8be785ad063.gif)

