### PR TITLE
fix: map/list switch overlay display

### DIFF
--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -109,7 +109,7 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
       >
         {isFallback ? `Seite Lädt...` : `${pageTitle}`}
       </h1>
-      <ul>
+      <ul className="pb-28">
         {!isFallback &&
           (filteredRecords.length !== originalRecords.length ||
             filteredRecords.length === 0) && (

--- a/src/components/MapLayout.tsx
+++ b/src/components/MapLayout.tsx
@@ -110,12 +110,15 @@ export const MapLayout: FC<{
           </div>
         )}
         {!isFallback && showMapUi && <MapButtons />}
-        {!isFallback && selectedFacilities.length === 0 && (
-          <MapListSwitch
-            listViewOpen={listViewOpen}
-            setListViewOpen={setListViewOpen}
-          />
-        )}
+        {!isFallback &&
+          isMobile &&
+          pathname === '/map' &&
+          selectedFacilities.length === 0 && (
+            <MapListSwitch
+              listViewOpen={listViewOpen}
+              setListViewOpen={setListViewOpen}
+            />
+          )}
         {showMapUi && listViewOpen && (
           <div
             className={classNames(


### PR DESCRIPTION
This PR fixes two tickets, WEG-159 and WEG-167.

We now don't display the map/list switch anymore when the routes is _not_ the map. We also add a bit of padding to the facilities list to make sure the switch (which is still displayed there on mobile) doesn't cover the content of the last facility in the list.