### PR TITLE
refactor(WEG-173): Hide Tags when all present

### DIFF
--- a/src/components/FacilityLabels.tsx
+++ b/src/components/FacilityLabels.tsx
@@ -28,6 +28,7 @@ export const FacilityLabels: FC<FacilityLabelsType> = ({
   const allFilters = useFiltersWithActiveProp()
   const tagsFilters = allFilters.filter(isGroup)
   const targetFilters = allFilters.filter(isTarget)
+  const someFiltersActive = allFilters.some(({ isActive }) => isActive)
   const tagsIncludesAllFilters = tagsFilters.every(({ id }) =>
     topicsLabels.find((filter) => filter.id === id)
   )
@@ -37,24 +38,26 @@ export const FacilityLabels: FC<FacilityLabelsType> = ({
 
   return (
     <>
-      {topicsLabels.length > 0 && (
-        <div className="px-5 text-sm leading-4">
-          {texts.filtersTagsLabelOnCard}:{' '}
-          <FiltersTextList
-            filters={topicsLabels}
-            includesAllFilters={tagsIncludesAllFilters}
-          />
-        </div>
-      )}
-      {targetAudienceLabels.length > 0 && (
-        <div className="px-5 text-sm leading-4">
-          {texts.filtersSearchTargetLabelOnCard}:{' '}
-          <FiltersTextList
-            filters={targetAudienceLabels}
-            includesAllFilters={targetIncludesAllFilters}
-          />
-        </div>
-      )}
+      {topicsLabels.length > 0 &&
+        !(tagsIncludesAllFilters && !someFiltersActive) && (
+          <div className="px-5 text-sm leading-4">
+            {texts.filtersTagsLabelOnCard}:{' '}
+            <FiltersTextList
+              filters={topicsLabels}
+              includesAllFilters={tagsIncludesAllFilters}
+            />
+          </div>
+        )}
+      {targetAudienceLabels.length > 0 &&
+        !(targetIncludesAllFilters && !someFiltersActive) && (
+          <div className="px-5 text-sm leading-4">
+            {texts.filtersSearchTargetLabelOnCard}:{' '}
+            <FiltersTextList
+              filters={targetAudienceLabels}
+              includesAllFilters={targetIncludesAllFilters}
+            />
+          </div>
+        )}
       {languages.length > 0 && (
         <div className="px-5 text-sm leading-4">
           {texts.languagesLabel}:{' '}


### PR DESCRIPTION
This PR hides the text saying "Themen: Alle"/"Speziell für: Alle" when the value is "Alle"

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/2759340/215773942-42580fe0-b644-4dbe-93d1-92bd467b6d0a.png)|![image](https://user-images.githubusercontent.com/2759340/215774158-d3f61ef7-6975-48a8-b61b-f964c46e02fd.png)| 