### PR TITLE
feat(WEG-163): Add opening hours help text

### DIFF
--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -236,6 +236,11 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
                 />
               </>
             )}
+            {parsedFacilty.openingTimesText && (
+              <p className="whitespace-pre-wrap p-5 pt-8">
+                {parsedFacilty.openingTimesText}
+              </p>
+            )}
           </div>
         )}
       </article>

--- a/src/lib/mapRecordToMinimum.ts
+++ b/src/lib/mapRecordToMinimum.ts
@@ -19,6 +19,7 @@ export interface MinimalRecordType
   labels: number[]
   languages: string[]
   open247: boolean
+  openingTimesText: string
   description: string
 }
 
@@ -32,6 +33,7 @@ export const mapRecordToMinimum = (record: TableRowType): MinimalRecordType => {
     labels: record.fields.Schlagworte,
     languages: splitString(record.fields.Sprachen, ','),
     open247: record.fields['c24_h_7_Tage'].trim() === 'ja',
+    openingTimesText: (record.fields['Weitere_Offnungszeiten'] || '').trim(),
     prioriy: mapPriorityToNumber(record.fields.Prio),
     description: sanitizeHtml(record.fields.Uber_uns, {
       allowedTags: [],


### PR DESCRIPTION
This PR adds the text "Weiter Öffnungszeiten" present in grist below the opening hours.

![CleanShot 2023-01-31 at 15 42 16](https://user-images.githubusercontent.com/2759340/215791326-776e59fc-68f9-4459-910a-78aeb8a0ba6e.png)
