### PR TITLE
feat(WEG-175): hide opening times when closed everyday

### DIFF
--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -72,6 +72,17 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
     }
   )
 
+  const closedRegex = /[gG]eschlossen/
+
+  const facilityClosedEveryDay =
+    closedRegex.test(facility.fields.Montag) &&
+    closedRegex.test(facility.fields.Dienstag) &&
+    closedRegex.test(facility.fields.Mittwoch) &&
+    closedRegex.test(facility.fields.Donnerstag) &&
+    closedRegex.test(facility.fields.Freitag) &&
+    closedRegex.test(facility.fields.Samstag) &&
+    closedRegex.test(facility.fields.Sonntag)
+
   const infoList = [
     {
       icon: <Geopin />,
@@ -197,7 +208,7 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
                 </p>
               </div>
             )}
-            {!parsedFacilty.open247 && (
+            {!parsedFacilty.open247 && !facilityClosedEveryDay && (
               <>
                 <OpenDaysItem
                   isActive={todayKey === 'Montag'}

--- a/src/components/FacilityInfo/index.tsx
+++ b/src/components/FacilityInfo/index.tsx
@@ -74,7 +74,7 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
 
   const closedRegex = /[gG]eschlossen/
 
-  const facilityClosedEveryDay =
+  const allDaysStateThatFacilityIsClosed =
     closedRegex.test(facility.fields.Montag) &&
     closedRegex.test(facility.fields.Dienstag) &&
     closedRegex.test(facility.fields.Mittwoch) &&
@@ -82,6 +82,12 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
     closedRegex.test(facility.fields.Freitag) &&
     closedRegex.test(facility.fields.Samstag) &&
     closedRegex.test(facility.fields.Sonntag)
+
+  const facilityIsLabelledAsOpen247 = parsedFacilty.open247
+
+  const everydayClosedButHasInfoText =
+    allDaysStateThatFacilityIsClosed &&
+    parsedFacilty.openingTimesText.length > 0
 
   const infoList = [
     {
@@ -208,7 +214,7 @@ export const FacilityInfo: FC<FacilityInfoType> = ({ facility }) => {
                 </p>
               </div>
             )}
-            {!parsedFacilty.open247 && !facilityClosedEveryDay && (
+            {!facilityIsLabelledAsOpen247 && !everydayClosedButHasInfoText && (
               <>
                 <OpenDaysItem
                   isActive={todayKey === 'Montag'}


### PR DESCRIPTION
This PR hides the table of opening times if the facility is closed all days (in the Grist table). Most of the times there is additional information in the "Weitere Öffnungszeiten" which is displayed below.