### PR TITLE
style(WEG-183): button and link styles

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -26,7 +26,7 @@ export const Label: FC<{
           `py-1.5 border text-lg flex gap-2 text-left leading-6 pl-2 pr-3 group rounded`,
           isActive &&
             isInteractive &&
-            `bg-primary border-primary text-white hover:bg-gray-60 focus:group-hover:bg-primary hover:border-gray-60`,
+            `bg-primary border-primary text-white focus:group-hover:bg-primary`,
           (!isActive || !isInteractive) && ` border-gray-20`,
           !isActive && isInteractive && 'hover:bg-gray-10',
           isInteractive && [

--- a/src/components/PrimaryButton.tsx
+++ b/src/components/PrimaryButton.tsx
@@ -21,8 +21,9 @@ export const PrimaryButton: FC<ButtonPropsType> = ({
       `bg-primary text-white rounded leading-7 transition-colors`,
       `font-medium text-left text-2xl relative items-center`,
       `grid grid-cols-[1fr,auto] w-full group font-bold`,
+      'group',
       !disabled && [
-        `hover:bg-white hover:text-primary border border-trasparent hover:border-primary`,
+        `border border-trasparent`,
         `focus:outline-none focus:ring-2 focus:ring-primary`,
         `focus:ring-offset-2 focus:ring-offset-white`,
       ],
@@ -36,7 +37,8 @@ export const PrimaryButton: FC<ButtonPropsType> = ({
     <span
       className={classNames(
         `w-14 h-14`,
-        `inline-flex items-center justify-center`
+        `inline-flex items-center justify-center`,
+        'transition-transform group-hover:translate-x-0.5'
       )}
     >
       <Arrow />


### PR DESCRIPTION
This PR improves the styling of interactive elements:

- the primary button now has a purple hover background plus a little moving arrow
- the labels don't have a gray hover background anymore