### PR TITLE
feat: add target group "Diverse"

### DIFF
--- a/src/common/types/gristData.ts
+++ b/src/common/types/gristData.ts
@@ -5,6 +5,7 @@ export interface GristLabelType extends Record<string, unknown> {
     text: string
     icon: string
     group2: 'gruppe-1' | 'gruppe-2' | 'gruppe-3' | 'zielpublikum'
+    order: number | null
   }
 }
 

--- a/src/components/FiltersList.tsx
+++ b/src/components/FiltersList.tsx
@@ -109,12 +109,19 @@ export const FiltersList: FC<{
           <RadioGroup
             className="mb-5"
             label={texts.filtersSearchTargetLabel}
-            options={targetGroups.map((group) => {
-              return {
-                value: `${group.id}`,
-                label: group.fields.text,
-              }
-            })}
+            options={targetGroups
+              .sort((a, b) => {
+                if (!a.fields.order) return 1
+                if (!b.fields.order) return -1
+
+                return a.fields.order - b.fields.order
+              })
+              .map((group) => {
+                return {
+                  value: `${group.id}`,
+                  label: group.fields.text,
+                }
+              })}
             activeValue={activeTargetGroupId || ''}
             onChange={(selectedValue) => {
               const targetGroupAlreadyInUrl = tags.some((tag) => {


### PR DESCRIPTION
This PR makes sure that we can define the target group "Diverse" in for facilities Grist. Note that we have added the column "order" to the Grist data table to specify an explicit sorting because we want the gender-related target groups to show up next to each other. this wouldn't have been possible without the column because Grist sorts records according to their creation date, i.e. a record added later will have a higher ID than a record added earlier.