### PR TITLE
chore: let Renovate Bot run against staging branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["@inpyjamas", ":disableDependencyDashboard"]
+  "extends": ["github>technologiestiftung/renovate-config"],
+  "baseBranches": ["staging"]
 }


### PR DESCRIPTION
This is to ensure that dependency updates don't break anything in Production. The Renovate config actually does allow automerge for non-major dev dependencies. Which sounds fine, but actually laready broke something before.