### PR TITLE
Staging to Main (Renovate config)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["@inpyjamas", ":disableDependencyDashboard"]
+  "extends": ["github>technologiestiftung/renovate-config"],
+  "baseBranches": ["staging"]
 }


### PR DESCRIPTION
Merging this to `main` ASAP to prevent further issues in Production because of Renovate's rules for non-major dev dependencies (which are allowed to automerge)