### PR TITLE
feat: don't show result counts and do show selected tags

### DIFF
--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -114,7 +114,7 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
         <title>
           {isFallback
             ? 'Seite Lädt...'
-            : `${texts.mapPageTitle} – ${texts.siteTitle}`}
+            : `${texts.resultPageTitle} – ${texts.siteTitle}`}
         </title>
       </Head>
       <ul className="pb-28">

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -14,6 +14,7 @@ import { useDistanceToUser } from '@lib/hooks/useDistanceToUser'
 import { useUserGeolocation } from '@lib/hooks/useUserGeolocation'
 import { useFiltersWithActiveProp } from '@lib/hooks/useFiltersWithActiveProp'
 import { getFilteredFacilities } from '@lib/facilityFilterUtil'
+import { Button } from '@components/Button'
 
 export const getStaticProps: GetStaticProps = async () => {
   const { texts, labels, records } = await loadData()
@@ -117,6 +118,28 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
             : `${texts.resultPageTitle} – ${texts.siteTitle}`}
         </title>
       </Head>
+      {labels.filter((label) => label.isActive).length > 0 && (
+        <div className="p-5 border-b border-gray-20 bg-gray-10 bg-opacity-25">
+          <p className="text-sm font-bold">{texts.resultPageIntro}</p>
+          <ul className="mt-2 md:mt-3 flex flex-wrap gap-1 md:gap-2">
+            {labels
+              .filter((label) => label.isActive)
+              .map((label) => (
+                <Button
+                  key={label.id}
+                  tag="button"
+                  disabled={true}
+                  scheme="primary"
+                  size="extrasmall"
+                  className="!bg-primary !text-white !cursor-default flex gap-x-1 items-center"
+                >
+                  {label.fields.text}
+                </Button>
+              ))}
+          </ul>
+        </div>
+      )}
+
       <ul className="pb-28">
         {filteredRecords.map((record) => (
           <FacilityListItem key={record.id} {...record} />

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -3,7 +3,6 @@ import Head from 'next/head'
 import { useTexts } from '@lib/TextsContext'
 import { Page } from '@common/types/nextPage'
 import { MapLayout } from '@components/MapLayout'
-import classNames from '@lib/classNames'
 import { FacilityListItem } from '@components/FacilityListItem'
 import { mapRecordToMinimum, MinimalRecordType } from '@lib/mapRecordToMinimum'
 import { GristLabelType } from '@common/types/gristData'
@@ -25,13 +24,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      texts: {
-        ...texts,
-        mapPageTitle: texts.mapPageTitle.replace(
-          '#number',
-          `${records.length}`
-        ),
-      },
+      texts,
       records: recordsWithOnlyMinimum,
       labels,
     },
@@ -45,7 +38,7 @@ interface MapProps {
 }
 
 const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
-  const [urlState, setUrlState] = useUrlState()
+  const [urlState] = useUrlState()
   const texts = useTexts()
   const { isFallback } = useRouter()
   const { getDistanceToUser } = useDistanceToUser()
@@ -115,47 +108,16 @@ const MapPage: Page<MapProps> = ({ records: originalRecords }) => {
     return setFilteredRecords(sortFacilities(filteredRecords))
   }, [urlState.tags?.join('-')])
 
-  const [pageTitle, setPageTitle] = useState(texts.mapPageTitle)
-
-  useEffect(() => {
-    setPageTitle(
-      texts.mapPageTitle.replace(/^\d\d?\d?/g, `${filteredRecords.length}`)
-    )
-  }, [filteredRecords, texts.mapPageTitle])
-
   return (
     <>
       <Head>
         <title>
-          {isFallback ? 'Seite Lädt...' : `${pageTitle} – ${texts.siteTitle}`}
+          {isFallback
+            ? 'Seite Lädt...'
+            : `${texts.mapPageTitle} – ${texts.siteTitle}`}
         </title>
       </Head>
-      <h1
-        className={classNames(
-          `hidden lg:block sticky top-0 z-10`,
-          `px-5 py-8 bg-white border-b border-gray-10`
-        )}
-      >
-        {isFallback ? `Seite Lädt...` : `${pageTitle}`}
-      </h1>
       <ul className="pb-28">
-        {!isFallback &&
-          (filteredRecords.length !== originalRecords.length ||
-            filteredRecords.length === 0) && (
-            <div className="p-5 text-lg border-y border-gray-20 bg-gray-10/50">
-              <button
-                onClick={() => setUrlState({ tags: [] })}
-                className={classNames(
-                  `cursor-pointer`,
-                  `underline transition-colors hover:text-primary`,
-                  `focus:outline-none focus:ring-2 focus:ring-primary`,
-                  `focus:ring-offset-2 focus:ring-offset-white`
-                )}
-              >
-                {texts.resetFilters}
-              </button>
-            </div>
-          )}
         {filteredRecords.map((record) => (
           <FacilityListItem key={record.id} {...record} />
         ))}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,79 @@
+import classNames from '@lib/classNames'
+import { FC } from 'react'
+
+interface ButtonType {
+  tag?: 'button' | 'a'
+  scheme?: 'primary' | 'secondary' | 'link'
+  size?: 'large' | 'medium' | 'small' | 'extrasmall'
+  href?: string
+  onClick?: () => void
+  disabled?: boolean
+  className?: string
+}
+
+const getSizeClasses = (size: ButtonType['size']): string => {
+  switch (size) {
+    case 'large':
+      return 'text-2xl py-3 px-5 rounded-lg'
+    case 'small':
+      return 'text-base py-2 px-3 rounded'
+    case 'extrasmall':
+      return 'text-sm py-1 px-2 rounded'
+    // case 'secondary':
+    default:
+      return 'text-lg py-2 px-4 rounded'
+  }
+}
+
+const getSchemeClasses = (scheme: ButtonType['scheme']): string => {
+  switch (scheme) {
+    case 'primary':
+      return 'bg-purple-500 text-white'
+    // case 'secondary':
+    default:
+      return 'bg-white text-gray-80 border border-gray-20'
+  }
+}
+
+export const Button: FC<ButtonType> = ({
+  tag = 'button',
+  scheme = 'secondary',
+  size = 'medium',
+  href,
+  onClick,
+  className: additionalClassNames = '',
+  disabled = false,
+  children,
+}) => {
+  const SIZE_CLASSES = getSizeClasses(size)
+  const SCHEME_CLASSES = getSchemeClasses(scheme)
+
+  const CLASSES = classNames(
+    'text-center flex justify-center',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+    SIZE_CLASSES,
+    SCHEME_CLASSES,
+    additionalClassNames
+  )
+
+  if (tag === 'a') {
+    return (
+      <a href={href} className={CLASSES}>
+        {children}
+      </a>
+    )
+  } else {
+    return (
+      <button
+        onClick={() => onClick && onClick()}
+        className={classNames(
+          CLASSES,
+          'disabled:bg-gray-20 disabled:text-gray-60 disabled:cursor-not-allowed'
+        )}
+        disabled={disabled}
+      >
+        {children}
+      </button>
+    )
+  }
+}

--- a/src/components/FiltersList.tsx
+++ b/src/components/FiltersList.tsx
@@ -21,7 +21,7 @@ export const FiltersList: FC<{
   const labels = useFiltersWithActiveProp()
   const [urlState, updateUrlState] = useUrlState()
 
-  const tags = useMemo(() => urlState.tags || [], [urlState.tags])
+  const queryTagIds = useMemo(() => urlState.tags || [], [urlState.tags])
 
   const {
     latitude,
@@ -42,7 +42,7 @@ export const FiltersList: FC<{
     ({ fields }) => fields.group2 === 'zielpublikum'
   )
   const someTargetFiltersActive = targetGroups.some((targetGroup) =>
-    tags.find((f) => f === targetGroup.id)
+    queryTagIds.find((f) => f === targetGroup.id)
   )
 
   const targetGroupIds = labels
@@ -50,25 +50,25 @@ export const FiltersList: FC<{
     .map((label) => label.id)
 
   const [activeTargetGroupId, setActiveTargetGroupId] = useState(
-    tags.find((tag) => {
-      return targetGroupIds.includes(tag)
+    queryTagIds.find((tagId) => {
+      return targetGroupIds.includes(tagId)
     })
   )
 
   useEffect(() => {
-    if (tags.length === 0) return
+    if (queryTagIds.length === 0) return
 
-    const currentTargetGroupId = tags.find((tag) =>
-      targetGroupIds.includes(tag)
+    const currentTargetGroupId = queryTagIds.find((tagId) =>
+      targetGroupIds.includes(tagId)
     )
     if (currentTargetGroupId) {
       setActiveTargetGroupId(currentTargetGroupId)
     }
-  }, [tags, targetGroupIds])
+  }, [queryTagIds, targetGroupIds])
 
   const someGroupFiltersActive = labels
     .filter(({ fields }) => fields.group2 !== 'zielpublikum')
-    .some(({ id }) => tags.find((f) => f === id))
+    .some(({ id }) => queryTagIds.find((f) => f === id))
 
   const updateFilters = (newTags: number[]): void => {
     updateUrlState({ tags: newTags })
@@ -87,7 +87,7 @@ export const FiltersList: FC<{
           <button
             onClick={() =>
               updateFilters(
-                tags.filter((f) => {
+                queryTagIds.filter((f) => {
                   const label = labels.find(({ id }) => id === f)
                   return label?.fields.group2 === `zielpublikum`
                 }) || []
@@ -117,20 +117,22 @@ export const FiltersList: FC<{
             })}
             activeValue={activeTargetGroupId || ''}
             onChange={(selectedValue) => {
-              const targetGroupAlreadyInUrl = tags.some((tag) => {
-                return targetGroupIds.includes(tag)
+              const targetGroupAlreadyInUrl = queryTagIds.some((tagId) => {
+                return targetGroupIds.includes(tagId)
               })
 
               if (targetGroupAlreadyInUrl) {
-                const tagsWithoutOldTargetGroup = tags.filter((tag) => {
-                  return !targetGroupIds.includes(tag)
-                })
+                const tagsWithoutOldTargetGroup = queryTagIds.filter(
+                  (tagId) => {
+                    return !targetGroupIds.includes(tagId)
+                  }
+                )
                 updateFilters([
                   ...tagsWithoutOldTargetGroup,
                   Number(selectedValue),
                 ])
               } else {
-                updateFilters([...tags, Number(selectedValue)])
+                updateFilters([...queryTagIds, Number(selectedValue)])
               }
             }}
           />
@@ -139,7 +141,7 @@ export const FiltersList: FC<{
           <button
             onClick={() => {
               updateFilters(
-                tags.filter((f) => {
+                queryTagIds.filter((f) => {
                   return !targetGroupIds.includes(f)
                 }) || []
               )
@@ -175,19 +177,19 @@ export const FiltersList: FC<{
               },
             })
           }}
-          disabled={tags.length > 0 && filteredFacilitiesCount === 0}
+          disabled={queryTagIds.length > 0 && filteredFacilitiesCount === 0}
           tooltip={
-            tags.length > 0 && filteredFacilitiesCount === 0
+            queryTagIds.length > 0 && filteredFacilitiesCount === 0
               ? texts.filtersButtonTextFilteredNoResultsHint
               : ''
           }
         >
-          {(tags.length === 0 || tags.length === labels.length) &&
+          {(queryTagIds.length === 0 || queryTagIds.length === labels.length) &&
             texts.filtersButtonTextResults}
-          {tags.length > 0 &&
+          {queryTagIds.length > 0 &&
             filteredFacilitiesCount >= 1 &&
             texts.filtersButtonTextResults}
-          {tags.length > 0 &&
+          {queryTagIds.length > 0 &&
             filteredFacilitiesCount === 0 &&
             texts.filtersButtonTextFilteredNoResults}
         </PrimaryButton>

--- a/src/components/FiltersList.tsx
+++ b/src/components/FiltersList.tsx
@@ -183,16 +183,10 @@ export const FiltersList: FC<{
           }
         >
           {(tags.length === 0 || tags.length === labels.length) &&
-            texts.filtersButtonTextAllFilters}
+            texts.filtersButtonTextResults}
           {tags.length > 0 &&
-            filteredFacilitiesCount === 1 &&
-            texts.filtersButtonTextFilteredSingular}
-          {tags.length > 0 &&
-            filteredFacilitiesCount > 1 &&
-            texts.filtersButtonTextFilteredPlural.replace(
-              '#number',
-              `${filteredFacilitiesCount}`
-            )}
+            filteredFacilitiesCount >= 1 &&
+            texts.filtersButtonTextResults}
           {tags.length > 0 &&
             filteredFacilitiesCount === 0 &&
             texts.filtersButtonTextFilteredNoResults}

--- a/src/components/FiltersList.tsx
+++ b/src/components/FiltersList.tsx
@@ -185,10 +185,16 @@ export const FiltersList: FC<{
           }
         >
           {(queryTagIds.length === 0 || queryTagIds.length === labels.length) &&
-            texts.filtersButtonTextResults}
+            texts.filtersButtonTextAllFilters}
           {queryTagIds.length > 0 &&
-            filteredFacilitiesCount >= 1 &&
-            texts.filtersButtonTextResults}
+            filteredFacilitiesCount === 1 &&
+            texts.filtersButtonTextFilteredSingular}
+          {queryTagIds.length > 0 &&
+            filteredFacilitiesCount > 1 &&
+            texts.filtersButtonTextFilteredPlural.replace(
+              '#number',
+              `${filteredFacilitiesCount}`
+            )}
           {queryTagIds.length > 0 &&
             filteredFacilitiesCount === 0 &&
             texts.filtersButtonTextFilteredNoResults}

--- a/src/lib/TextsContext.tsx
+++ b/src/lib/TextsContext.tsx
@@ -90,6 +90,7 @@ const defaultValue = {
   alwaysOpened: '',
   mapPageTitle: '',
   resultPageTitle: '',
+  resultPageIntro: '',
   weekdayMonday: '',
   weekdayTuesday: '',
   weekdayWednesday: '',

--- a/src/lib/TextsContext.tsx
+++ b/src/lib/TextsContext.tsx
@@ -89,6 +89,7 @@ const defaultValue = {
   opened: '',
   alwaysOpened: '',
   mapPageTitle: '',
+  resultPageTitle: '',
   weekdayMonday: '',
   weekdayTuesday: '',
   weekdayWednesday: '',

--- a/src/lib/TextsContext.tsx
+++ b/src/lib/TextsContext.tsx
@@ -75,6 +75,7 @@ const defaultValue = {
   emergencyTrepotowKoepenickPhoneNumber: '',
   welcomeFiltersHeadline: '',
   welcomeFiltersText: '',
+  filtersButtonTextResults: '',
   filtersButtonTextFilteredSingular: '',
   filtersButtonTextFilteredPlural: '',
   filtersButtonTextFilteredNoResults: '',


### PR DESCRIPTION
This PR removes the result counts from the UI. Feedback revealed that it was overwhelming for users instead of being helpful.

- [x] bring back count to buttons
- [x] remove count from list view header
- [x] remove count from page title
- [x] add indicator to reult list of which tags were selected
- [x] remove texts that reference unused filter texts