### PR TITLE
update-semantic-release-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - run: npm ci
       - id: semantic-release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 18
         env:


### PR DESCRIPTION
We use a semantic release action version that will stop working soon see https://github.blog/changelog/2022-***0-***-github-actions-deprecating-save-state-and-set-output-commands/