### PR TITLE
fix(useMaplibreMap): Make sure only one map instance is created

### DIFF
--- a/src/lib/hooks/useMaplibreMap.ts
+++ b/src/lib/hooks/useMaplibreMap.ts
@@ -10,8 +10,10 @@ export function useMaplibreMap(config: {
   minZoom: number
 }): Map | null {
   const map = useRef<Map>(null)
+  const mapIsInitialized = useRef<boolean>(false)
   // Map setup (run only once on initial render)
   useEffect(() => {
+    if (mapIsInitialized.current) return
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     map.current = new Map({
@@ -24,6 +26,7 @@ export function useMaplibreMap(config: {
       minZoom: config.minZoom,
       maxZoom: config.maxZoom,
     })
+    mapIsInitialized.current = true
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 


### PR DESCRIPTION
In react 18, `useEffect` calls are done twice to ensure applications are reliant to rerenders. This happens only locally, as a prevention measure. This is why it wasn't broken on deployed version but only locally. Thx to @dnsos for the tipp. We now make sure to track if a map was initialized and don't recreate an instance if so. We should make sure to test against double `useEffect` calls in the future.

A good article about this: https://medium.com/geekculture/the-tricky-behavior-of-useeffect-hook-in-react-18-282ef4fb570a