### PR TITLE
refactor(revalidation): Remove nextjs revalidation

### DIFF
--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -40,7 +40,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       labels,
       center: [record.fields.long, record.fields.lat],
     },
-    revalidate: 120,
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,6 @@ export const getStaticProps: GetStaticProps = async () => {
   )
   return {
     props: { texts, recordsWithOnlyLabels, labels },
-    revalidate: 120,
   }
 }
 

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -29,7 +29,6 @@ export const getStaticProps: GetStaticProps = async () => {
       records: recordsWithOnlyMinimum,
       labels,
     },
-    revalidate: 120,
   }
 }
 

--- a/pages/sofortige-hilfe.tsx
+++ b/pages/sofortige-hilfe.tsx
@@ -14,7 +14,6 @@ export const getStaticProps: GetStaticProps = async () => {
   const texts = await getGristTexts()
   return {
     props: { texts },
-    revalidate: 120,
   }
 }
 


### PR DESCRIPTION
This PR removes next.js revalidation on all pages. The reason is that when the GRIST Database contains formatting errors in some rows, the revalidation might fail and this can result in the overview being out of sync with individual facility pages. And because revalidation serves the previous version of a page, it fails silently and this is a problem.

We chose to use a webhook to deploy the website completely, which would completely fail with formatting errors and therefore would be noticed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204095712094652